### PR TITLE
Add collapsing behaviour to tags in demographics

### DIFF
--- a/interface/tags_filters/views/tags_demographics.php
+++ b/interface/tags_filters/views/tags_demographics.php
@@ -17,16 +17,23 @@
                            href="javascript;"
                            class="css_button_small tags-cancel-button"><span>Cancel</span></a>
                     </td>
-                    <td><span class="text"><b>Tags</b></span></td>
+                    <td>
+                        <a href="javascript:;" id="tags_container" class="small" onclick="toggleTagsIndicator()">
+                            <span class="text"><b>Tags</b></span>
+                            (<span class="indicator">expand</span>)
+                        </a>
+                    </td>
                 </tr>
                 </tbody>
             </table>
         </div>
 
         <?php if ( acl_check( 'patients', 'demo', '', 'write' ) ) { ?>
-            <div class="notab" id="TAGS">
-                <img id="tags-ajax-loading"style="padding:8px;" src="../../pic/ajax-loader.gif">
-                <div id="tags-content"></div>
+            <div id="tags_ps_expand" style="display: none;">
+                <div class="notab" id="TAGS">
+                    <img id="tags-ajax-loading"style="padding:8px;" src="../../pic/ajax-loader.gif">
+                    <div id="tags-content"></div>
+                </div>
             </div>
             <script type="text/javascript">
                 $(document).ready( function () {
@@ -40,6 +47,7 @@
                         e.stopPropagation();
                         e.preventDefault();
                         var url = '<?php echo $GLOBALS['webroot']; ?>/interface/tags_filters/index.php?action=patients!edit&pid=<?php echo $_SESSION['pid']; ?>';
+                        expandTagsIndicator();
                         $("#tags-content").hide();
                         $("#tags-ajax-loading").show();
                         $("#tags-content").load( url, function() {
@@ -90,3 +98,26 @@
         <?php } ?>
     </td>
 </tr>
+
+<script type="text/javascript">
+
+    function expandTagsIndicator() {
+      $("#tags_container").find(".indicator").text( "<?php echo htmlspecialchars(xl('collapse'),ENT_QUOTES); ?>" );
+      $("#tags_ps_expand").show();
+    }
+
+    function collapseTagsIndicator() {
+      $("#tags_container").find(".indicator").text( "<?php echo htmlspecialchars(xl('expand'),ENT_QUOTES); ?>" );
+      $("#tags_ps_expand").hide();
+    }
+
+    function toggleTagsIndicator() {
+        $mode = $("#tags_container").find(".indicator").text();
+        if ( $mode == "<?php echo htmlspecialchars(xl('collapse'),ENT_QUOTES); ?>" ) {
+            collapseTagsIndicator();
+        } else {
+            expandTagsIndicator();
+        }
+    }
+
+</script>


### PR DESCRIPTION
Fixes #405 

I think the demographics page can be further refined by modifying the `expand_collapse_widget` function to accept an array of Buttons and using that for the tags and other stuff in the future.

Also, I noticed a tiny bug: When you have no tags and you click on "Add" and then "Cancel", the "No tags found" message disappears. It's replicable on the online demo. Not sure if there's an issue already created for it.

Thanks!