### PR TITLE
Add phone number formatting

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -512,7 +512,7 @@ $GLOBALS_METADATA = array(
        'num',
        '3',
       xl('If YMD is selected for age display, switch to just Years when patients older than this value in years')
-    ),      
+    ),
   ),
 
   // Features Tab
@@ -613,7 +613,7 @@ $GLOBALS_METADATA = array(
        '0',                             // default
       xl('Set a facility cookie to remember the selected facility between logins.')
     ),
-    
+
 
     'discount_by_money' => array(
       xl('Discounts as Monetary Amounts'),
@@ -651,7 +651,7 @@ $GLOBALS_METADATA = array(
        '0',                             // default = true
       xl('This will use the custom immunizations list rather than the standard CVX immunization list.')
     ),
-      
+
     'amendments' => array (
         xl('Amendments'),
          'bool',                        // data type
@@ -660,11 +660,11 @@ $GLOBALS_METADATA = array(
     ),
 
   ),
-  
+
   // Report Tab
   //
   'Report' => array(
-    
+
     'use_custom_daysheet' => array(
       xl('Use Custom End of Day Report'),
       array(
@@ -676,7 +676,7 @@ $GLOBALS_METADATA = array(
        '1',                             // default = Print End of Day Report 1
       xl('This will allow the use of the custom End of Day report and indicate which report to use.')
     ),
-     
+
     'daysheet_provider_totals' => array(
       xl('End of Day by Provider or allow Totals Only'),
       array(
@@ -717,7 +717,7 @@ $GLOBALS_METADATA = array(
       ),
        '2',                             // default = 2
       xl('This will Display the Invoice Number in the Sales Report or the Patient Name and ID or Patient Name and Invoice Number.')
-    ), 
+    ),
 
     'cash_receipts_report_invoice' => array(
       xl('Display Invoice Number or Patient Name in the Cash Receipt Report'),
@@ -735,20 +735,20 @@ $GLOBALS_METADATA = array(
       '0',                              // default
       xl('Causes Receipts to Print Encounter/Primary Provider Info')
   ),
-   
+
     'activate_ccr_ccd_report' => array(
       xl('Activate CCR/CCD Reporting'),
       'bool',                           // data type
       '1',                              // default = true
       xl('This will activate the CCR(Continuity of Care Record) and CCD(Continuity of Care Document) reporting.')
     ),
-    
+
   ),
-   
+
     // Demographics Tab
   //
     'Demographic' => array(
-    
+
     'insurance_information' => array(
       xl('Show Additional Insurance Information'),               // descriptive name
       array(
@@ -778,14 +778,14 @@ $GLOBALS_METADATA = array(
       '0',                              // default = false
       xl('This will force the Billing Widget in the Patient Summary screen to always be open.')
     ),
-  
+
     'omit_employers' => array(
       xl('Omit Employers'),
       'bool',                           // data type
       '0',                              // default = false
       xl('Omit employer information in patient demographics')
     ),
-  
+
     'advance_directives_warning' => array(
       xl('Advance Directives Warning'),
       'bool',                           // data type
@@ -796,10 +796,10 @@ $GLOBALS_METADATA = array(
     'allow_pat_delete' => array(
        xl('Allow Administrators to Delete Patients'),
        'bool',                           // data type
-       '1',                              // default = true 
+       '1',                              // default = true
        xl('Allow Administrators to Delete Patients')
 
-    ),  
+    ),
 
     'floating_message_alerts' => array(
       xl('Show Floating Alerts for User Messages'),
@@ -826,9 +826,22 @@ $GLOBALS_METADATA = array(
        '0:20',                          // default
       xl('The Re-Display Time in Seconds for the Floating Alerts.')
     ),
-    
+
+    'phone_number_format' => array(
+      xl('Phone Number Format'),
+      array(
+        '($1) $2-$3' => '(XXX) XXX-XXXX',   // $1: 3 digits, $2: 3 digits, $3: 4 digits
+        '($1) $2 $3' => '(XXX) XXX XXXX',
+        '$1-$2-$3' => 'XXX-XXX-XXXX',
+        '$1 $2 $3' => 'XXX XXX XXXX',
+        '$1$2$3' => 'XXXXXXXXXX'
+      ),
+      '($1) $2-$3',                    //default
+      xl('The format to display phone numbers in.')
+    )
+
   ),
-   
+
     // Encounters Tab
     //
     'Encounter' => array(
@@ -846,7 +859,7 @@ $GLOBALS_METADATA = array(
       '0',                              // default = false
       xl('This will disable the Edit button on all forms whose parent encounter is e-signed')
     ),
-            
+
     'esign_individual' => array(
       xl('Allows E-Signing Individual Forms'),
       'bool',                           // data type
@@ -860,7 +873,7 @@ $GLOBALS_METADATA = array(
       '1',                              // default = false
       xl('This will disable the Edit button on any form that is e-signed')
     ),
-            
+
     'esign_lock_toggle' => array(
       xl('Enable lock toggle'),
       'bool',                           // data type
@@ -874,7 +887,7 @@ $GLOBALS_METADATA = array(
       '1',                              // default = false
       xl('This will hide empty e-sign logs on the patient report')
     ),
-    
+
     'support_encounter_claims' => array(
       xl('Allow Encounter Claims'),
       'bool',                           // data type
@@ -903,7 +916,7 @@ $GLOBALS_METADATA = array(
       '20',
       xl('Number of encounters to display per page.')
     ),
-    
+
     'default_encounter_view' => array(
       xl('Default Encounter View'),               // descriptive name
       array(
@@ -920,7 +933,7 @@ $GLOBALS_METADATA = array(
       'ICD10',                 // default
       xl('The default code type to search for in the Fee Sheet.')
     ),
-    
+
     'support_fee_sheet_line_item_provider' => array(
        xl('Support provider in line item in fee sheet'),
         'bool',                         // data type
@@ -934,7 +947,7 @@ $GLOBALS_METADATA = array(
         '0',                            // default = false
        xl('Default to a provider for line item in the fee sheet.(only applicable if Support line item billing in option above)')
     ),
- 
+
     'replicate_justification' => array(
       xl('Automatically replicate justification codes in Fee Sheet'),
        'bool',                          // data type
@@ -947,7 +960,7 @@ $GLOBALS_METADATA = array(
         '0',                            // default = false
        xl('Allows Fee Sheet Items to be excluded from Insurance Billing')
     ),
-   
+
     'default_chief_complaint' => array(
       xl('Default Reason for Visit'),
       'text',                           // data type
@@ -961,20 +974,20 @@ $GLOBALS_METADATA = array(
       '',
       xl('To automatically open the specified form. Some sports teams use football_injury_audit here.')
     ),
-   
+
   ),
-    
+
   // Billing Tab
-    
+
   'Billing' => array(
- 
+
     'use_charges_panel' => array(
       xl('Use Charges Panel'),
       'bool',                           // data type
       '0',                              // default = false
       xl('Enables the old Charges panel for entering billing codes and payments. Not recommended, use the Fee Sheet instead.')
     ),
- 
+
     'display_units_in_billing' => array(
       xl('Display the Units Column on the Billing Screen'),
         'bool',                         // data type
@@ -1010,7 +1023,7 @@ $GLOBALS_METADATA = array(
        'N0',                            // default = Allow All
       xl('Do not Allow Deletion of Payments older that this selection.')
     ),
- 
+
    'inactivate_insurance_companies' => array(
       xl('Allow Insurance Companies to be Inactivated'),
       'bool',
@@ -1018,9 +1031,9 @@ $GLOBALS_METADATA = array(
       xl('This Will Allow Individual Insurance Companies to be Inactivated')
 
   ),
-  
+
   ),
-  
+
   // Statement Tab
   //
   'Statement' => array(
@@ -1047,7 +1060,7 @@ $GLOBALS_METADATA = array(
        '',
        xl('Phone number for billing inquiries')
      ),
- 
+
     'show_aging_on_custom_statement' => array(
       xl('Show Aging on Custom Statement'),
        'bool',                          // data type
@@ -1176,8 +1189,8 @@ $GLOBALS_METADATA = array(
   ),
 
   // Claim Tab
-  //  
-  'Claim' => array(    
+  //
+  'Claim' => array(
     'preprinted_cms_1500' => array(
       xl('Prints the CMS 1500 on the Preprinted form.'),
        'bool',                          // data type
@@ -1230,8 +1243,8 @@ $GLOBALS_METADATA = array(
       xl('This specifies whether to include date in Box 31.')
     ),
   ),
-  
-  
+
+
   //Documents Tab
   //
   'Documents' => array(
@@ -1259,7 +1272,7 @@ $GLOBALS_METADATA = array(
        '',
       xl('Username to connect to CouchDB'),
     ),
-    
+
     'couchdb_pass' => array(
       xl('CouchDB Password'),
        'text',
@@ -1315,7 +1328,7 @@ $GLOBALS_METADATA = array(
       '1',                              // default = true
       xl('This will deactivate document the encryption and decryption features, and hide them in the UI.')
     ),
-    
+
   ),
 
   // Calendar Tab
@@ -1436,7 +1449,7 @@ $GLOBALS_METADATA = array(
        '0',                             // default = false
       xl('A positive number will show that many past appointments on a Widget in the Patient Summary screen (a negative number will show the past appointments in descending order)')
     ),
-    
+
     'event_color' => array(
       xl('Appointment/Event Color'),
       array(
@@ -1526,8 +1539,8 @@ $GLOBALS_METADATA = array(
         'M6' => xl('Six Months Ahead'),
         'M3' => xl('Three Months Ahead'),
         'M1' => xl('One Month Ahead'),
-        'D1' => xl('One Day Ahead'),        
-      ),                       
+        'D1' => xl('One Day Ahead'),
+      ),
       'Y1',                     // default = One Year
       xl('This is the Ending date for the Patient Flow Board Date Range. (only applicable if Allow Date Range in option above is Enabled)')
     ),
@@ -1929,7 +1942,7 @@ $GLOBALS_METADATA = array(
             '3' => '5162'
     ),
 
-        '1', // default 
+        '1', // default
         xl('Avery Label type for printing patient labels from popups in left nav screen'),
     ),
 
@@ -1987,7 +2000,7 @@ $GLOBALS_METADATA = array(
        '1',
       xl('Enables the ability to download documents in the Onsite Patient Portal by the user.')
     ),
- 
+
 
   ),
 
@@ -2010,7 +2023,7 @@ $GLOBALS_METADATA = array(
     ),
 
     ),
-  
+
     // Mail Tab
   //
   'Mail' => array(
@@ -2070,21 +2083,21 @@ $GLOBALS_METADATA = array(
        '0',
       xl('phiMail Allow CCR Send')
     ),
-    
+
     'patient_reminder_sender_name' => array(
       xl('Patient Reminder Sender Name'),
       'text',                           // data type
       '',                               // default
       xl('Name of the sender for patient reminders.')
     ),
-    
+
     'patient_reminder_sender_email' => array(
       xl('Patient Reminder Sender Email'),
       'text',                           // data type
       '',                               // default
       xl('Email address of the sender for patient reminders. Replies to patient reminders will be directed to this address. It is important to use an address from your clinic\'s domain to avoid help prevent patient reminders from going to junk mail folders.')
     ),
-    
+
     'practice_return_email_path' => array(
       xl('Notification Email Address'),
       'text',                           // data type
@@ -2141,20 +2154,20 @@ $GLOBALS_METADATA = array(
       '',
       xl('SMTP security protocol to connect with. Required by some servers such as gmail.')
     ),
-    
+
     'EMAIL_NOTIFICATION_HOUR' => array(
       xl('Email Notification Hours'),
       'num',                            // data type
       '50',                             // default
       xl('Number of hours in advance to send email notifications.')
     ),
-    
+
   ),
 
   // RX
   //
   'Rx' => array(
-  
+
     'rx_enable_DEA' => array(
       xl('Rx Enable DEA #'),
        'bool',                          // data type
@@ -2281,7 +2294,7 @@ $GLOBALS_METADATA = array(
        '30',
       xl('Rx Bottom Margin (px)')
     ),
-    
+
     'erx_enable' => array(
       xl('Enable NewCrop eRx Service'),
       'bool',
@@ -2397,11 +2410,11 @@ $GLOBALS_METADATA = array(
         '0',
         xl('Log all NewCrop eRx Requests and / or Responses.'),
     ),
-    
-  ),  
-    
+
+  ),
+
   'PDF' => array (
-  
+
    'pdf_layout' => array (
       xl('Layout'),
       array(
@@ -2411,7 +2424,7 @@ $GLOBALS_METADATA = array(
        'P',                             // defaut
       xl("Choose Layout Direction"),
     ),
-    
+
     'pdf_language' => array (
       xl('PDF Language'),
       array(
@@ -2602,7 +2615,7 @@ $GLOBALS_METADATA = array(
        'en',                            // default English
       xl('Choose PDF languange Preference'),
     ),
-   
+
     'pdf_size' => array(
       xl('Paper Size'),                // Descriptive Name
       array(
@@ -2659,35 +2672,35 @@ $GLOBALS_METADATA = array(
        'LETTER',
       xl('Choose Paper Size')
     ),
-    
+
     'pdf_left_margin' => array(
       xl('Left Margin (mm)'),
        'num',
        '5',
       xl('Left Margin (mm)')
     ),
-    
+
     'pdf_right_margin' => array(
       xl('Right Margin (mm)'),
        'num',
        '5',
       xl('Right Margin (mm)')
     ),
-    
+
     'pdf_top_margin' => array(
       xl('Top Margin (mm)'),
        'num',
        '5',
       xl('Top Margin (mm)')
     ),
-    
+
     'pdf_bottom_margin' => array(
       xl('Bottom Margin (px)'),
        'num',
        '8',
       xl('Bottom Margin (px)')
     ),
-   
+
     'pdf_output' => array (
       xl('Output Type'),
       array(
@@ -2699,7 +2712,7 @@ $GLOBALS_METADATA = array(
     ),
 
    ),
-  
+
   // Security Tab
   //
   'Security' => array(
@@ -2781,7 +2794,7 @@ $GLOBALS_METADATA = array(
     ),
 
   ),
-  
+
     // System Tab
     //
     'System' => array(
@@ -2813,14 +2826,14 @@ $GLOBALS_METADATA = array(
       $backup_log_dir,                  // default
       xl('Full path to directory for event log backup.')
     ),
-    
+
     'print_command' => array(
       xl('Print Command'),
       'text',                           // data type
       'lpr -P HPLaserjet6P -o cpi=10 -o lpi=6 -o page-left=72 -o page-top=72',
       xl('Shell command for printing from the server.')
     ),
-    
+
     'gb_how_sort_list' => array(
       xl('How to sort the lists and categories'),
       array(
@@ -2830,7 +2843,7 @@ $GLOBALS_METADATA = array(
       '0',
       xl('What kind of sorting will be used for the lists and categories.')
     ),
- 
+
     'gb_how_sort_categories' => array(
       xl('How to sort the categories'),
       array(
@@ -2840,13 +2853,13 @@ $GLOBALS_METADATA = array(
       '1',
       xl('What kind of sorting will be used for the categories.')
     ),
-    
+
   ),
-  
+
     // Fax Tab
     //
     'Fax' => array(
-    
+
     'enable_hylafax' => array(
       xl('Enable Hylafax Support'),
       'bool',                           // data type
@@ -2880,7 +2893,7 @@ $GLOBALS_METADATA = array(
     // Scanner Tab
     //
     'Scanner' => array(
-    
+
     'enable_scanner' => array(
       xl('Enable Scanner Support'),
       'bool',                           // data type
@@ -2894,9 +2907,9 @@ $GLOBALS_METADATA = array(
       '/mnt/scan_docs',                 // default
       xl('Location where scans are stored.')
     ),
-    
+
   ),
-  
+
 );
 
 if ( function_exists( 'do_action' ) ) {

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -1703,7 +1703,7 @@ function generate_display_field($frow, $currvalue) {
   // simple text field
   else if ($data_type == 2) {
     // phone number
-    if(strpos($frow['edit_options'], 'P') !== NULL) {
+    if(strpos($frow['edit_options'], 'P') !== false) {
       $phone = preg_replace("/[^0-9]/", "", $currvalue);    // strip everything except the digits
       $formatted_phone = preg_replace("/^(\d{3})(\d{3})(\d{4})$/", $GLOBALS['phone_number_format'], $phone);
 

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -82,29 +82,29 @@ function optionalAge($frow, $date, &$asof) {
 //
 function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_name = ' ', $class = '',
         $onchange = '', $tag_id = '', $custom_attributes = null, $multiple = false, $backup_list = '') {
-    $s = '';    
-    
+    $s = '';
+
     $tag_name_esc = attr($tag_name);
-    
+
     if ($multiple) {
         $tag_name_esc = $tag_name_esc . "[]";
     }
     $s .= "<select name='$tag_name_esc'";
-    
+
     if ($multiple) {
         $s .= " multiple='multiple'";
     }
-    
+
     $tag_id_esc = $tag_name_esc;
     if ($tag_id != '') {
         $tag_id_esc = attr($tag_id);
     }
-    
+
     if ($multiple) {
         $tag_id_esc = $tag_id_esc . "[]";
     }
     $s .= " id='$tag_id_esc'";
-    
+
     if ($class) {
                 $class_esc = attr($class);
         $s .= " class='$class_esc'";
@@ -165,10 +165,10 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
                 "ORDER BY " . $order_by_sql, array($lang_id, $list_id));
         }
     $got_selected = FALSE;
-    
+
     while ( $lrow = sqlFetchArray ( $lres ) ) {
         $selectedValues = explode ( "|", $currvalue );
-        
+
         $optionValue = attr($lrow ['option_id']);
         $s .= "<option value='$optionValue'";
 
@@ -176,7 +176,7 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
             $s .= " selected";
             $got_selected = TRUE;
         }
-        
+
         $optionLabel = text($lrow ['title']);
         $s .= ">$optionLabel</option>\n";
     }
@@ -210,27 +210,27 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
             $fontTitle = xlt('Please choose a valid selection from the list.');
             $fontText = xlt( 'Fix this' );
             $s .= " <font color='red' title='$fontTitle'>$fontText!</font>";
-        }       
-        
+        }
+
     } else if (!$got_selected && strlen ( $currvalue ) > 0 && $multiple) {
         //if not found in main list, display all selected values that exist in backup list
         $list_id = $backup_list;
-        
-        
+
+
         $got_selected_backup = FALSE;
         if (!empty($backup_list)) {
             $lres_backup = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity = 1 ORDER BY seq, title", array($list_id));
             while ( $lrow_backup = sqlFetchArray ( $lres_backup ) ) {
                 $selectedValues = explode ( "|", $currvalue );
-            
+
                 $optionValue = attr($lrow_backup['option_id']);
-            
-                if ($multiple && (strlen ( $currvalue ) == 0 && $lrow_backup ['is_default']) || 
+
+                if ($multiple && (strlen ( $currvalue ) == 0 && $lrow_backup ['is_default']) ||
                         (strlen ( $currvalue ) > 0 && in_array ( $lrow_backup ['option_id'], $selectedValues ))) {
                     $s .= "<option value='$optionValue'";
                     $s .= " selected";
                     $optionLabel = text(xl_list_label($lrow_backup ['title']));
-                    $s .= ">$optionLabel</option>\n";               
+                    $s .= ">$optionLabel</option>\n";
                     $got_selected_backup = TRUE;
                 }
             }
@@ -243,12 +243,12 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
             $s .= " <font color='red' title='$fontTitle'>$fontText!</font>";
         }
     }
-    
+
     else {
         $s .= "</select>";
     }
     return $s;
-    
+
 }
 
 // $frow is a row from the layout_options table.
@@ -265,12 +265,12 @@ function generate_form_field($frow, $currvalue) {
   $list_id     = $frow['list_id'];
   $backup_list = $frow['list_backup_id'];
   $condition_str = get_conditions_str($condition_str,$frow);
-  
+
   // escaped variables to use in html
   $field_id_esc= htmlspecialchars( $field_id, ENT_QUOTES);
   $list_id_esc = htmlspecialchars( $list_id, ENT_QUOTES);
 
-  // Added 5-09 by BM - Translate description if applicable  
+  // Added 5-09 by BM - Translate description if applicable
   $description = (isset($frow['description']) ? htmlspecialchars(xl_layout_label($frow['description']), ENT_QUOTES) : '');
 
   // Support edit option T which assigns the (possibly very long) description as
@@ -293,12 +293,12 @@ function generate_form_field($frow, $currvalue) {
     $showEmpty = false;
     $empty_title = "Unassigned";
    }
-   else {     
+   else {
     $empty_title = $frow['empty_title'];
    }
   }
   else {
-   $empty_title = "Unassigned";   
+   $empty_title = "Unassigned";
   }
 
   $disabled = strpos($frow['edit_options'], '0') === FALSE ? '' : 'disabled';
@@ -706,7 +706,7 @@ function generate_form_field($frow, $currvalue) {
 
       // Added 5-09 by BM - Translate label if applicable
       echo " $disabled />" . htmlspecialchars( xl_list_label($lrow['title']), ENT_NOQUOTES);
-    
+
       echo "</td>";
     }
     if ($count) {
@@ -785,10 +785,10 @@ function generate_form_field($frow, $currvalue) {
       $option_id_esc = htmlspecialchars( $option_id, ENT_QUOTES);
       $restype = substr($avalue[$option_id], 0, 1);
       $resnote = substr($avalue[$option_id], 2);
-    
+
       // Added 5-09 by BM - Translate label if applicable
       echo "<tr><td>" . htmlspecialchars( xl_list_label($lrow['title']), ENT_NOQUOTES) . "&nbsp;</td>";
-    
+
       for ($i = 0; $i < 3; ++$i) {
         $inputValue = htmlspecialchars( $i, ENT_QUOTES);
         echo "<td><input type='radio'" .
@@ -852,7 +852,7 @@ function generate_form_field($frow, $currvalue) {
 
       // Added 5-09 by BM - Translate label if applicable
       echo "<tr><td>" . htmlspecialchars( xl_list_label($lrow['title']), ENT_NOQUOTES) . "&nbsp;</td>";
-    
+
       $option_id = htmlspecialchars( $option_id, ENT_QUOTES);
       echo "<td><input type='checkbox' name='check_{$field_id_esc}[$option_id_esc]'" .
         " id='check_{$field_id_esc}[$option_id_esc]' value='1' $lbfonchange";
@@ -870,7 +870,7 @@ function generate_form_field($frow, $currvalue) {
     }
     echo "</table>";
   }
-  
+
   // single-selection list with ability to add to it
   else if ($data_type == 26) {
     echo generate_select_list("form_$field_id", $list_id, $currvalue,
@@ -886,7 +886,7 @@ function generate_form_field($frow, $currvalue) {
     }
     else {
      // no specific aco exist for this list, so check for access to 'default' list
-     if (acl_check('lists', 'default')) echo $outputAddButton;  
+     if (acl_check('lists', 'default')) echo $outputAddButton;
     }
   }
 
@@ -940,7 +940,7 @@ function generate_form_field($frow, $currvalue) {
     $tmp = explode('|', $currvalue);
     switch(count($tmp)) {
       case "4": {
-        $resnote = $tmp[0]; 
+        $resnote = $tmp[0];
         $restype = $tmp[1];
         $resdate = $tmp[2];
         $reslist = $tmp[3];
@@ -976,7 +976,7 @@ function generate_form_field($frow, $currvalue) {
     echo "<tr>";
     if ($data_type == 28)
     {
-    // input text 
+    // input text
     echo "<td><input type='text'" .
       " name='form_$field_id_esc'" .
       " id='form_$field_id_esc'" .
@@ -1072,7 +1072,7 @@ function generate_form_field($frow, $currvalue) {
   }
 
   //facilities drop-down list
-  else if ($data_type == 35) {   
+  else if ($data_type == 35) {
     if (empty($currvalue)){
       $currvalue = 0;
     }
@@ -1085,7 +1085,7 @@ function generate_form_field($frow, $currvalue) {
   else if ($data_type == 36) {
     echo generate_select_list("form_$field_id", $list_id, $currvalue,
       $description, $showEmpty ? $empty_title : '', '', $onchange, '', null, true, $backup_list);
-    
+
   }
 }
 
@@ -1101,7 +1101,7 @@ function generate_print_field($frow, $currvalue) {
   $backup_list = $frow['list_backup_id'];
 
   $description = htmlspecialchars(xl_layout_label($frow['description']), ENT_QUOTES);
-      
+
   // Can pass $frow['empty_title'] with this variable, otherwise
   //  will default to 'Unassigned'.
   // If it is 'SKIP' then an empty text title is completely skipped.
@@ -1112,12 +1112,12 @@ function generate_print_field($frow, $currvalue) {
       $showEmpty = false;
       $empty_title = "Unassigned";
     }
-    else {     
+    else {
       $empty_title = $frow['empty_title'];
     }
   }
   else {
-    $empty_title = "Unassigned";   
+    $empty_title = "Unassigned";
   }
 
   // generic single-selection list
@@ -1571,14 +1571,14 @@ function generate_print_field($frow, $currvalue) {
       " value='$resnote' /></td>";
     echo "<td class='bold'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".
       "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".
-      htmlspecialchars( xl('Status'), ENT_NOQUOTES).":&nbsp;</td>";  
-    } 
+      htmlspecialchars( xl('Status'), ENT_NOQUOTES).":&nbsp;</td>";
+    }
     else if($data_type == 32)
     {
     echo "<tr><td><input type='text'" .
       " size='$fldlength'" .
       " class='under'" .
-      " value='$resnote' /></td></tr>"; 
+      " value='$resnote' /></td></tr>";
     $fldlength = 30;
     $smoking_status_title = generate_display_field(array('data_type'=>'1','list_id'=>$list_id),$reslist);
     echo "<td><input type='text'" .
@@ -1590,20 +1590,20 @@ function generate_print_field($frow, $currvalue) {
     echo "<td><input type='radio'";
     if ($restype == "current".$field_id) echo " checked";
     echo "/>".htmlspecialchars( xl('Current'), ENT_NOQUOTES)."&nbsp;</td>";
-    
+
     echo "<td><input type='radio'";
     if ($restype == "current".$field_id) echo " checked";
     echo "/>".htmlspecialchars( xl('Quit'), ENT_NOQUOTES)."&nbsp;</td>";
-    
+
     echo "<td><input type='text' size='6'" .
       " value='$resdate'" .
       " class='under'" .
       " /></td>";
-    
+
     echo "<td><input type='radio'";
     if ($restype == "current".$field_id) echo " checked";
     echo " />".htmlspecialchars( xl('Never'), ENT_NOQUOTES)."</td>";
-    
+
     echo "<td><input type='radio'";
     if ($restype == "not_applicable".$field_id) echo " checked";
     echo " />".htmlspecialchars( xl('N/A'), ENT_NOQUOTES)."&nbsp;</td>";
@@ -1615,7 +1615,7 @@ function generate_print_field($frow, $currvalue) {
   else if ($data_type == 31) {
     echo nl2br($frow['description']);
   }
-  
+
   else if($data_type == 34){
     echo "<a href='../../../library/custom_template/custom_template.php?type=form_{$field_id}&contextName=".htmlspecialchars($list_id_esc,ENT_QUOTES)."' class='iframe_medium' style='text-decoration:none;color:black;'>";
     echo "<div id='form_{$field_id}_div' class='text-area'></div>";
@@ -1642,7 +1642,7 @@ function generate_print_field($frow, $currvalue) {
         }
     }
     $tmp = '';
-    
+
     $values_array = explode("|", $currvalue);
 
         $i=0;
@@ -1659,7 +1659,7 @@ function generate_print_field($frow, $currvalue) {
             }
             if (empty($tmp)) $tmp = "($value)";
         }
-        
+
         if ($tmp === '') {
             $tmp = '&nbsp;';
         }
@@ -1681,7 +1681,7 @@ function generate_display_field($frow, $currvalue) {
   $field_id   = isset($frow['field_id'])  ? $frow['field_id'] : null;
   $list_id    = $frow['list_id'];
   $backup_list = $frow['list_backup_id'];
-  
+
   $s = '';
 
   // generic selection list or the generic selection list with add on the fly
@@ -1702,7 +1702,17 @@ function generate_display_field($frow, $currvalue) {
 
   // simple text field
   else if ($data_type == 2) {
-     $s = nl2br(htmlspecialchars($currvalue,ENT_NOQUOTES));
+    // phone number
+    if(strpos($frow['edit_options'], 'P') !== NULL) {
+      $phone = preg_replace("/[^0-9]/", "", $currvalue);    // strip everything except the digits
+      $formatted_phone = preg_replace("/^(\d{3})(\d{3})(\d{4})$/", $GLOBALS['phone_number_format'], $phone);
+
+      $s = nl2br(htmlspecialchars($formatted_phone,ENT_NOQUOTES));
+
+    }
+    else {
+      $s = nl2br(htmlspecialchars($currvalue,ENT_NOQUOTES));
+    }
   }
 
   // long or multi-line text field
@@ -1771,7 +1781,7 @@ function generate_display_field($frow, $currvalue) {
         $uname = $urow['organization'];
     }else{
         $uname = $urow['lname'];
-        if ($urow['fname']) $uname .= ", " . $urow['fname'];        
+        if ($urow['fname']) $uname .= ", " . $urow['fname'];
     }
     $s = htmlspecialchars($uname,ENT_NOQUOTES);
   }
@@ -1818,10 +1828,10 @@ function generate_display_field($frow, $currvalue) {
       $option_id = $lrow['option_id'];
       if (in_array($option_id, $avalue)) {
         if ($count++) $s .= "<br />";
-      
+
     // Added 5-09 by BM - Translate label if applicable
         $s .= nl2br(htmlspecialchars(xl_list_label($lrow['title'])),ENT_NOQUOTES);
-        
+
       }
     }
   }
@@ -1841,10 +1851,10 @@ function generate_display_field($frow, $currvalue) {
     while ($lrow = sqlFetchArray($lres)) {
       $option_id = $lrow['option_id'];
       if (empty($avalue[$option_id])) continue;
-    
+
       // Added 5-09 by BM - Translate label if applicable
       $s .= "<tr><td class='bold' valign='top'>" . htmlspecialchars(xl_list_label($lrow['title']),ENT_NOQUOTES) . ":&nbsp;</td>";
-      
+
       $s .= "<td class='text' valign='top'>" . htmlspecialchars($avalue[$option_id],ENT_NOQUOTES) . "</td></tr>";
     }
     $s .= "</table>";
@@ -1867,10 +1877,10 @@ function generate_display_field($frow, $currvalue) {
       $restype = substr($avalue[$option_id], 0, 1);
       $resnote = substr($avalue[$option_id], 2);
       if (empty($restype) && empty($resnote)) continue;
-    
+
       // Added 5-09 by BM - Translate label if applicable
       $s .= "<tr><td class='bold' valign='top'>" . htmlspecialchars(xl_list_label($lrow['title']),ENT_NOQUOTES) . "&nbsp;</td>";
-    
+
       $restype = ($restype == '1') ? xl('Normal') : (($restype == '2') ? xl('Abnormal') : xl('N/A'));
       // $s .= "<td class='text' valign='top'>$restype</td></tr>";
       // $s .= "<td class='text' valign='top'>$resnote</td></tr>";
@@ -1913,11 +1923,11 @@ function generate_display_field($frow, $currvalue) {
       $restype = substr($avalue[$option_id], 0, 1);
       $resnote = substr($avalue[$option_id], 2);
       if (empty($restype) && empty($resnote)) continue;
-    
-      // Added 5-09 by BM - Translate label if applicable   
+
+      // Added 5-09 by BM - Translate label if applicable
       $s .= "<tr><td class='bold' valign='top'>" . htmlspecialchars(xl_list_label($lrow['title']),ENT_NOQUOTES) . "&nbsp;</td>";
-    
-      $restype = $restype ? xl('Yes') : xl('No');  
+
+      $restype = $restype ? xl('Yes') : xl('No');
       $s .= "<td class='text' valign='top'>" . htmlspecialchars($restype,ENT_NOQUOTES) . "</td></tr>";
       $s .= "<td class='text' valign='top'>" . htmlspecialchars($resnote,ENT_NOQUOTES) . "</td></tr>";
       $s .= "</tr>";
@@ -1955,7 +1965,7 @@ function generate_display_field($frow, $currvalue) {
       } break;
     }
     $s .= "<table cellpadding='0' cellspacing='0'>";
-      
+
     $s .= "<tr>";
     $res = "";
     if ($restype == "current".$field_id) $res = xl('Current');
@@ -1971,13 +1981,13 @@ function generate_display_field($frow, $currvalue) {
      //VicarePlus :: Tobacco field has a listbox, text box, date field and 3 radio buttons.
      else if ($data_type == 32)
     {//changes on 5-jun-2k14 (regarding 'Smoking Status - display SNOMED code description')
-       $smoke_codes = getSmokeCodes(); 
+       $smoke_codes = getSmokeCodes();
        if (!empty($reslist)) {
            if($smoke_codes[$reslist]!="")
                $code_desc = "( ".$smoke_codes[$reslist]." )";
-           
+
            $s .= "<td class='text' valign='top'>" . generate_display_field(array('data_type'=>'1','list_id'=>$list_id),$reslist) . "&nbsp;".text($code_desc)."&nbsp;&nbsp;&nbsp;&nbsp;</td>";}
-       
+
        if (!empty($resnote)) $s .= "<td class='text' valign='top'>" . htmlspecialchars($resnote,ENT_NOQUOTES) . "&nbsp;&nbsp;</td>";
     }
 
@@ -1991,7 +2001,7 @@ function generate_display_field($frow, $currvalue) {
   else if ($data_type == 31) {
     $s .= nl2br($frow['description']);
   }
-  
+
   else if($data_type == 34){
     $arr = explode("|*|*|*|",$currvalue);
     for($i=0;$i<sizeof($arr);$i++){
@@ -2010,18 +2020,18 @@ function generate_display_field($frow, $currvalue) {
   //  Supports backup lists
   else if ($data_type == 36) {
     $values_array = explode("|", $currvalue);
-    
+
     $i = 0;
     foreach($values_array as $value) {
       $lrow = sqlQuery("SELECT title FROM list_options " .
           "WHERE list_id = ? AND option_id = ?", array($list_id,$value) );
-      
+
       if ($lrow == 0 && !empty($backup_list)) {
         //use back up list
         $lrow = sqlQuery("SELECT title FROM list_options " .
                 "WHERE list_id = ? AND option_id = ?", array($backup_list,$value) );
       }
-      
+
       if ($i > 0) {
         $s = $s . ", " . htmlspecialchars(xl_list_label($lrow['title']),ENT_NOQUOTES);
       } else {
@@ -2225,7 +2235,7 @@ function generate_plaintext_field($frow, $currvalue) {
       if (empty($restype) && empty($resnote)) continue;
       if ($s !== '') $s .= '; ';
       $s .= xl_list_label($lrow['title']);
-      $restype = $restype ? xl('Yes') : xl('No');  
+      $restype = $restype ? xl('Yes') : xl('No');
       $s .= $restype;
       if ($resnote) $s .= ' ' . $resnote;
     }
@@ -2372,10 +2382,10 @@ function display_layout_rows($formtype, $result1, $result2='') {
         echo "<td class='groupname'>";
         //echo "<td class='groupname' style='padding-right:5pt' valign='top'>";
         //echo "<font color='#008800'>$group_name</font>";
-    
+
         // Added 5-09 by BM - Translate label if applicable
         echo htmlspecialchars(xl_layout_label($group_name),ENT_NOQUOTES);
-      
+
         $group_name = '';
       } else {
         //echo "<td class='' style='padding-right:5pt' valign='top'>";
@@ -2405,7 +2415,7 @@ function display_layout_rows($formtype, $result1, $result2='') {
     if ($datacols > 0) {
       disp_end_cell();
       //echo "<td class='text data' colspan='$datacols' valign='top'";
-      $datacols_esc = htmlspecialchars( $datacols, ENT_QUOTES);      
+      $datacols_esc = htmlspecialchars( $datacols, ENT_QUOTES);
       echo "<td class='text data' colspan='$datacols_esc'";
       //if ($cell_count > 0) echo " style='padding-left:5pt'";
       echo ">";
@@ -2460,7 +2470,7 @@ function display_layout_tabs_data($formtype, $result1, $result2='') {
         $currvalue  = '';
 
         if (substr($this_group,1,8) === 'Employer' && $GLOBALS['omit_employers']) continue;
-        
+
         $group_fields_query = sqlStatement("SELECT * FROM layout_options " .
         "WHERE form_id = ? AND uor > 0 AND group_name = ? " .
         "ORDER BY seq", array($formtype, $this_group) );
@@ -2598,7 +2608,7 @@ function display_layout_tabs_data_editable($formtype, $result1, $result2='') {
         $currvalue  = '';
 
         if (substr($this_group,1,8) === 'Employer' && $GLOBALS['omit_employers']) continue;
-        
+
         $group_fields_query = sqlStatement("SELECT * FROM layout_options " .
         "WHERE form_id = ? AND uor > 0 AND group_name = ? " .
         "ORDER BY seq", array($formtype,$this_group) );
@@ -2677,7 +2687,7 @@ function display_layout_tabs_data_editable($formtype, $result1, $result2='') {
                     }
 
                     ++$item_count;
-                    
+
                     echo generate_form_field($group_fields, $currvalue);
                   }
             ?>
@@ -2889,7 +2899,7 @@ function dropdown_facility($selected = '', $name = 'form_facility', $allow_unspe
 
   if ($allow_allfacilities) {
     $option_value = '';
-    $option_selected_attr = ''; 
+    $option_selected_attr = '';
     if ($selected == '') {
       $option_selected_attr = ' selected="selected"';
       $have_selected = true;
@@ -2906,7 +2916,7 @@ function dropdown_facility($selected = '', $name = 'form_facility', $allow_unspe
     $option_content = htmlspecialchars('-- ' . xl('Unspecified') . ' --', ENT_NOQUOTES);
     echo "    <option value=\"$option_value\" $option_selected_attr>$option_content</option>\n";
     }
-  
+
   while ($frow = sqlFetchArray($fres)) {
     $facility_id = $frow['id'];
     $option_value = htmlspecialchars($facility_id, ENT_QUOTES);
@@ -3155,14 +3165,14 @@ function lbf_current_value($frow, $formid, $encounter) {
 }
 # Generates a dropdown list for providers. This Code added by Terry Hill teryhill@librehealth.io
 # If you specify the $allprov it will list everyone that has an entry in the NPI field.
-function genProviderSelect($selname, $toptext, $default=0, $disabled=false, $allprov=false) 
+function genProviderSelect($selname, $toptext, $default=0, $disabled=false, $allprov=false)
 {
   if($allprov == 1) {
   $query = "SELECT id, lname, mname, fname, suffix FROM users WHERE " .
     "( authorized = 1 OR npi != '' ) " .
     "AND active = 1 " .
     "ORDER BY lname, fname";
-  } else { 
+  } else {
      $query = "SELECT id, lname, mname, fname, suffix FROM users WHERE " .
     "authorized = 1 AND username != '' " .
     "AND active = 1 " .


### PR DESCRIPTION
Fixes #439 

A limitation of this code is that it assumes all formatting options to be added in the future to be in `3 3 4` , i.e, US format. An advantage of this is that people can add new formats by just including it in the `globals.inc.php` file. If need be, I can expand this code for the general case, but that model would require extra effort for people using the system to add new formats (since they'll have to write regex). Opinions?

The check for phone numbers is done (for now) using layout_options.edit_options value

EDIT: Please check lines 829-842 of global_inc.php and lines 1705-1715 of options_inc.php for the diffs