### PR TITLE
Database cloning Turbo Mode

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -567,7 +567,8 @@ $config = 1; /////////////
     $backup_file = $this->get_backup_filename();
     $cmd = "mysqldump -u " . escapeshellarg($login) .
       " -p" . escapeshellarg($pass) .
-      " --opt --skip-extended-insert --quote-names -r $backup_file " .
+      " --opt --quote-names -r $backup_file " .
+      //" --opt --skip-extended-insert --quote-names -r $backup_file " .  Comment out above line and enable this to have really slow DB duplication.
       escapeshellarg($dbase);
     
     $tmp0 = exec($cmd, $tmp1=array(), $tmp2);


### PR DESCRIPTION
" --opt --quote-names -r $backup_file " .
//" --opt --skip-extended-insert --quote-names -r $backup_file " .
Comment out above line and enable this to have really slow DB
duplication.
This change speeds up cloning of the database for backup or launching a
new site from a template DB by a factor of about 600.
  This is used in production, and has launched ~45 production sites dependably.