### PR TITLE
setup broken by missing old calendar

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -70,8 +70,6 @@ $billingDirectory2 = "$OE_SITE_DIR/era";
 $billingLogDirectory = "$OE_SITE_DIR/logs";
 $lettersDirectory = "$OE_SITE_DIR/letter_templates";
 $gaclWritableDirectory = dirname(__FILE__)."/gacl/admin/templates_c";
-$requiredDirectory1 = dirname(__FILE__)."/interface/main/calendar/modules/PostCalendar/pntemplates/compiled";
-$requiredDirectory2 = dirname(__FILE__)."/interface/main/calendar/modules/PostCalendar/pntemplates/cache";
 
 $zendModuleConfigFile = dirname(__FILE__)."/interface/modules/zend_modules/config/application.config.php";
 
@@ -79,7 +77,7 @@ $zendModuleConfigFile = dirname(__FILE__)."/interface/modules/zend_modules/confi
 // correct permissions.
 if (is_dir($OE_SITE_DIR)) {
   $writableFileList = array($installer->conffile,$zendModuleConfigFile);
-  $writableDirList = array($docsDirectory, $billingDirectory, $billingDirectory2, $lettersDirectory, $gaclWritableDirectory, $requiredDirectory1, $requiredDirectory2);
+  $writableDirList = array($docsDirectory, $billingDirectory, $billingDirectory2, $lettersDirectory, $gaclWritableDirectory);
 }
 else {
   $writableFileList = array();


### PR DESCRIPTION
discovered by bclee
quote: " Just to clarify WHY this change is being made:
requiredDirectory1 and requiredDirectory2 were setup to make sure
permissions were set correctly for old calendar directories. These
directories no longer exist. The setup script complains and stops
because the directories '' and '' were not writable. Those are null
strings. These variables were commented out, but needed to be removed
from the list of directories that get checked."