### PR TITLE
MIPS Medicare Update

### DIFF
--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -697,11 +697,11 @@ function test_rules_clinic($provider='',$type='',$dateTarget='',$mode='',$patien
   }
 
   // Collect applicable patient pids in only medicare
-if (strpos($type, 'pqrs_individual') !== false ) {
-	$onlyMedicarePatients=true;	
-} else {
+//if (strpos($type, 'pqrs_individual') !== false ) {
+//	$onlyMedicarePatients=true;	
+//} else {
 	$onlyMedicarePatients=false;
-}
+//}
 
   $patientData = array();
   $patientData = buildPatientArray($patient_id,$provider,$pat_prov_rel,$start,$batchSize, false, $onlyMedicarePatients);

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3121,7 +3121,12 @@ $GLOBALS_METADATA = array(
       'FIXME vendor unique id FIXME!!!',            // default
       xl('MIPS Registry Name')
     ),
-
+     'pqrs_attestation_date' => array(
+      xl('Default Direct Entry Date'),	
+      'text',                           // data type
+      '2017-06-06',            // default
+      xl('Default date that direct entry encounters will be created on.')
+    ),
   ),
 
 );

--- a/modules/MIPS/SQL/1_INSTALL/PQRS_billingcodes.sql
+++ b/modules/MIPS/SQL/1_INSTALL/PQRS_billingcodes.sql
@@ -72,16 +72,13 @@ CREATE TABLE IF NOT EXISTS `codes` (
   `taxrates` varchar(255) NOT NULL default '',
   `cyp_factor` float NOT NULL default '0' COMMENT 'quantity representing a years supply',
   `active` tinyint(1) default '1' COMMENT '0 = inactive, 1 = active',
+  `exclude_from_insurance_billing` TINYINT(1) DEFAULT '0' COMMENT '0 = include, 1 = exclude',
   `reportable` tinyint(1) default '0' COMMENT '0 = non-reportable, 1 = reportable',
   `financial_reporting` tinyint(1) default '0' COMMENT '0 = negative, 1 = considered important code in financial reporting',
   PRIMARY KEY  (`id`),
   KEY `code` (`code`),
   KEY `code_type` (`code_type`)
 ) AUTO_INCREMENT=16643 ;
-
---
--- Dumping data for table `codes`
---
 
 
 


### PR DESCRIPTION
1.  Provides default date global for direct entry encounters when in
reporting mode (to be implemented later).
2.  Removes (temporarily) clinical rules check for Medicare.  This may
be required conditionally for 2018 MIPS standards.