### PR TITLE
Added "If you don't find the sql-mode in my.ini"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -199,6 +199,7 @@ In Linux it's typically located in /etc/mysql
         sql_mode="" (Blank)
 ```
 
+(XAMPP)
 If you don't find this parametery in my.ini file, you should run server, open http://localhost/phpmyadmin/ , click on the "variables" tab, search for "sql mode" and then check that it is set to:"" (Blank)
 
 In order to take full advantage of the patient documents capability you must make sure that settings in `php.ini` file include `file_uploads = On`, that `upload_max_filesize` is appropriate for your use, and that `upload_tmp_dir` is set to a correct value that will work on your system.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -191,11 +191,15 @@ OR (left click ) wampmanager icon -> MYSQL -> my.ini
 In Linux it's typically located in /etc/mysql
 
     1.  Look for the following line:
+    sql-mode = STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+    or sometimes it maybe sql_mode
 
     2.  Change it to:
 ```
         sql_mode="" (Blank)
 ```
+
+If you don't find this parametery in my.ini file, you should run server, open http://localhost/phpmyadmin/ , click on the "variables" tab, search for "sql mode" and then check that it is set to:"" (Blank)
 
 In order to take full advantage of the patient documents capability you must make sure that settings in `php.ini` file include `file_uploads = On`, that `upload_max_filesize` is appropriate for your use, and that `upload_tmp_dir` is set to a correct value that will work on your system.
 


### PR DESCRIPTION
I've added what should you do if you don't find "sql-mode" parameter in my.ini file and I added the missing piece of text: 
"sql-mode = STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
    or sometimes it maybe sql_mode"