### PR TITLE
Windows Installation Docs: Added "If you don't find the sql-mode in my.ini"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -200,7 +200,7 @@ In Linux it's typically located in /etc/mysql
 ```
 
 (XAMPP)
- If you don't find this parametery in my.ini file, you should run server, open http://localhost/phpmyadmin/ , click on the "variables" tab, search for "sql mode" and then check that it is set to:"" (Blank)
+ If you don't find this parameter in the my.ini file, you should run server, open http://localhost/phpmyadmin/, click on the "variables" tab, search for "sql mode", and then set it to:""
 
 In order to take full advantage of the patient documents capability you must make sure that settings in `php.ini` file include `file_uploads = On`, that `upload_max_filesize` is appropriate for your use, and that `upload_tmp_dir` is set to a correct value that will work on your system.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -191,11 +191,16 @@ OR (left click ) wampmanager icon -> MYSQL -> my.ini
 In Linux it's typically located in /etc/mysql
 
     1.  Look for the following line:
+    sql-mode = STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+    or sometimes it maybe sql_mode
 
     2.  Change it to:
 ```
         sql_mode="" (Blank)
 ```
+
+(XAMPP)
+ If you don't find this parametery in my.ini file, you should run server, open http://localhost/phpmyadmin/ , click on the "variables" tab, search for "sql mode" and then check that it is set to:"" (Blank)
 
 In order to take full advantage of the patient documents capability you must make sure that settings in `php.ini` file include `file_uploads = On`, that `upload_max_filesize` is appropriate for your use, and that `upload_tmp_dir` is set to a correct value that will work on your system.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In Linux it's typically located in /etc/mysql
 Restart WAMPP/XAMPP Server.
 
 (XAMPP)
- If you don't find this parametery in my.ini file, you should run server, open http://localhost/phpmyadmin/ , click on the "variables" tab, search for "sql mode" and then check that it is set to:"" (Blank)
+ If you don't find this parameter in the my.ini file, you should run server, open http://localhost/phpmyadmin/, click on the "variables" tab, search for "sql mode", and then set it to:""
 
 You can fork & clone the repository for local development. To get started you need to:
  - Clone the repository

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ In Linux it's typically located in /etc/mysql
 
 Restart WAMPP/XAMPP Server.
 
+(XAMPP)
+ If you don't find this parametery in my.ini file, you should run server, open http://localhost/phpmyadmin/ , click on the "variables" tab, search for "sql mode" and then check that it is set to:"" (Blank)
+
 You can fork & clone the repository for local development. To get started you need to:
  - Clone the repository
  - Run index.php file which then redirects to setup page! Follow the instructions and you are done!!


### PR DESCRIPTION
I've added what should you do if you don't find "sql-mode" parameter in my.ini file (README.md and INSTALL.md) and I added the missing piece of text (INSTALL.md):
"sql-mode = STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
or sometimes it maybe sql_mode"