### PR TITLE
Print insurance name on statement

### DIFF
--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -298,6 +298,9 @@ if (($_POST['form_print'] || $_POST['form_download'] || $_POST['form_pdf']) || $
         $stmt['level_closed'] = $row['last_level_closed'];
         $stmt['patient'] = $row['fname'] . ' ' . $row['lname'];
       $stmt['encounter'] = $row['encounter'];
+        $stmt['insconum1'] = "";
+        $stmt['insconum2'] = "";
+        $stmt['insconum3'] = "";
         #If you use the field in demographics layout called
         #guardiansname this will allow you to send statements to the parent
         #of a child or a guardian etc
@@ -313,6 +316,24 @@ if (($_POST['form_print'] || $_POST['form_download'] || $_POST['form_pdf']) || $
         $stmt['ins_paid'] = 0;
         $stmt['today'] = $today;
         $stmt['duedate'] = $duedate;
+        $patient_id = $row['pid'];
+        for ($i = 1; $i <= 3; ++$i) {
+         $payerid = arGetPayerID($patient_id, $svcdate, $i);
+
+         if ($payerid) {
+          $tmp = sqlQuery("SELECT name FROM insurance_companies WHERE id = $payerid");
+          if ($i == 1) {
+          $stmt['insconum1'] = $tmp['name'];
+          }
+          if ($i == 2) {
+          $stmt['insconum2'] = $tmp['name'];
+          }
+          if ($i == 3) {
+          $stmt['insconum3'] = $tmp['name'];
+          }
+
+         }
+        }
       } else {
         // Report the oldest due date.
         if ($duedate < $stmt['duedate']) {

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1123,6 +1123,13 @@ $GLOBALS_METADATA = array(
       xl('This will Show Aging on the custom Statement.')
     ),
 
+    'show_insurance_name_on_custom_statement' => array(
+      xl('Show Insurance Company Name on Custom Statement'),
+       'bool',                          // data type
+       '0',                             // default = false
+      xl('This will Show Insurance Company Name on the custom Statement Instead of Insurance information on file.')
+    ),
+
     'use_statement_print_exclusion' => array(
       xl('Allow Statement to be Excluded from Printing'),
        'bool',                          // data type

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -517,7 +517,18 @@ if ($GLOBALS['use_dunning_message']) {
  $label_addressee = xl('ADDRESSEE');
  $label_remitto = xl('REMIT TO');
  $label_chartnum = xl('Chart Number');
+ if ($GLOBALS['show_insurance_name_on_custom_statement']) { 
+ if (strlen($stmt['insconum2']) !=0){
+    $label_insinfo = xl('Insurance Companies '). $stmt['insconum1'] . ', '. $stmt['insconum2'];
+ }
+else
+ {
+   $label_insinfo = xl('Insurance Company '). $stmt['insconum1'] ;
+ }
+ }else{
  $label_insinfo = xl('Insurance information on file');
+ }    
+ 
  $label_totaldue = xl('Total amount due');
  $label_payby = xl('If paying by');
  $label_cards = xl('VISA/MC/AMEX/Dis');

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -161,7 +161,17 @@ function create_HTML_statement($stmt) {
   $label_addressee = xl('ADDRESSEE');
   $label_remitto = xl('REMIT TO');
   $label_chartnum = xl('Chart Number');
+  if ($GLOBALS['show_insurance_name_on_custom_statement']) { 
+   if (strlen($stmt['insconum2']) !=0){
+      $label_insinfo = xl('Insurance Companies '). $stmt['insconum1'] . ', '. $stmt['insconum2'];
+   }
+   else
+   {
+     $label_insinfo = xl('Insurance Company '). $stmt['insconum1'] ;
+   }
+  }else{
   $label_insinfo = xl('Insurance information on file');
+  }
   $label_totaldue = xl('Total amount due');
   $label_payby = xl('If paying by');
   $label_cards = xl('VISA/MC/Discovery/HSA');


### PR DESCRIPTION
Print insurance company name on statement instead of "Insurance information on file". I am working on the not printing the statements based on insurance company and thought this would be a good addition.