### PR TITLE
Added Bootstrap to all compatible elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+sites/default/edi/history/edi_history_log.txt

--- a/interface/billing/edih_view.php
+++ b/interface/billing/edih_view.php
@@ -26,6 +26,7 @@
 $sanitize_all_escapes=true; 
 $fake_register_globals=false; 
 require_once(dirname(__FILE__) . "/../globals.php");
+require_once("$srcdir/headers.inc.php");
 //
 if (!acl_check('acct', 'eob')) die(xlt("Access Not Authorized"));
 //
@@ -40,9 +41,11 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <head>
-    <title><?php echo xlt("edi history"); ?></title>
+    <title><?php echo xlt("EDI History"); ?></title>
     <meta http-equiv="content-type" content="text/html;charset=utf-8" />
-    
+    <?php
+        call_required_libraries(['bootstrap']);
+    ?>
     <link rel="stylesheet" href="<?php echo $css_header?>" type="text/css" />
 
     <link rel="stylesheet" href="<?php echo $web_root?>/library/css/jquery-ui-1.8.21.custom.css" type="text/css" />
@@ -104,13 +107,19 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
         <tr>
         <td colspan='4'>
         
+        <style>
+            td {
+                padding: 5px;
+            }
+        </style>
+
         <form id="formcsvtables" name="view_csv" action="edi_history_main.php" target="_blank" method="post">
             <fieldset style='float:left'>
                 <legend><?php echo xlt("View CSV tables"); ?>:</legend>
                 <table cols='4'>
                     <tr>
                         <td colspan='4'>
-                            <?php echo xlt("Select a percentage of the rows or or select dates"); ?>
+                            <?php echo xlt("Select a percentage of the rows or select dates"); ?>
                         </td>
                     </tr>
                     <tr>
@@ -118,10 +127,10 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
                             <?php echo xlt("Select CSV table"); ?>:
                         </td>
                         <td align='center'>
-                            <?php echo xlt("Pct (%) of rows"); ?>
+                            <?php echo xlt("% of rows"); ?>
                         </td>
                         <td align='left'>
-                            <?php echo xlt("Start Date"); ?>: &nbsp;&nbsp;&nbsp;&nbsp; <?php echo xlt("End Date"); ?>:
+                            <?php echo xlt("Start Date"); ?> & <?php echo xlt("End Date"); ?>
                         </td>
                         <td align='center'>
                             <?php echo xlt("Submit"); ?>
@@ -129,12 +138,12 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
                     </tr>
                     <tr height='1.5em'>
                         <td align='center'>                 
-                            <select id='csvselect' name="csvtables"> 
+                            <select id='csvselect' name="csvtables" class="form-control form-rounded"> 
                             </select>               
                         </td>                       
                             
                         <td align='center'>
-                            <select id="csvpct" name="csvpctrows">
+                            <select id="csvpct" name="csvpctrows" class="form-control form-rounded">
                                 <option value="5" selected="selected">5%</option>
                                 <option value="10">10%</option>
                                 <option value="25">25%</option>
@@ -145,9 +154,9 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
                         </td>
                         <!-- datekeyup(e, defcc, withtime)  dateblur(e, defcc, withtime) -->
                         <td align='left'>
-                           <input type='text' size='8' name='csv_date_start' id='caldte1' value='' title='yyyy-mm-dd Start Date' />
+                           <input type='text' class="form-control form-rounded" placeholder="<?php echo xlt('Start Date'); ?>" size='8' name='csv_date_start' id='caldte1' value='' title='yyyy-mm-dd Start Date' />
                         
-                           <input type='text' size='8' name='csv_date_end' id='caldte2' value='' title='yyyy-mm-dd End Date' />
+                           <input type='text' class="form-control form-rounded" placeholder="<?php echo xlt('End Date'); ?>" size='8' name='csv_date_end' id='caldte2' value='' title='yyyy-mm-dd End Date' />
                         </td>
                         
                         <!--
@@ -172,29 +181,18 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
         <form id="formcsvhist" name="csv_ch" action="edi_history_main.php" target="_blank" method="get">
            <fieldset style='float:left'>
               <legend><?php echo xlt("Per Encounter"); ?></legend>
+
               <table cols='2'> 
                     <tr>
-                        <td colspan='2'>
-                            <?php echo xlt("Enter Encounter Number"); ?>
-                        </td>
-                    </tr>
-                    <tr>
                         <td>
-                            <?php echo xlt("Encounter"); ?>
-                        </td>
-                        <td>
-                            <?php echo xlt("Submit"); ?>
-                        </td>   
-                    </tr>
-                    <tr>
-                        <td>
-                            <input id="csvenctr" type="text" size=7 name="chenctr" value="" />
+                            <input id="csvenctr" class="form-control form-rounded" placeholder="Encounter Number" type="text" size=15 name="chenctr" value="" />
                         </td>
                         <td>
                             <input id="showhistory" type="button" value="<?php echo xla("Submit"); ?>" />
                         </td>
                     </tr>
               </table>
+              <br><br><br><br><br>
             </fieldset>
         </form>
                 
@@ -219,6 +217,7 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
                 <label for="era_file"><?php echo xlt("Filename"); ?>:</label>
                 <input id="era_file" type="file" size=20 name="fileUplEra"  />
                 <input type="submit" name="fileERA" value="<?php echo xla("Submit"); ?>" /> 
+                <br><br><br><br><br><br><br><br><br><br><br>
             </fieldset>
             </form> 
         </td>
@@ -227,13 +226,13 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
         <fieldset style='float:left'>
           <legend><?php echo xlt("RA for Patient, Encounter, or Trace"); ?>:</legend>
             <label for="pid835"><?php echo xlt("Patient ID"); ?>:</label>
-            <input type="text" size=10 name="pid835" value="" />    
-            <input type="submit" name="subpid835" value="<?php echo xla("Submit"); ?>" /> <br />
+            <input type="text" class="form-control form-rounded" size=10 name="pid835" value="" />    
+            <input type="submit"  name="subpid835" value="<?php echo xla("Submit"); ?>" /> <br />
             <label for="enctr835"><?php echo xlt("Encounter"); ?>:</label>
-            <input type="text" size=10 name="enctr835" value="" />
+            <input type="text" class="form-control form-rounded" size=10 name="enctr835" value="" />
             <input type="submit" name="subenctr835" value="<?php echo xla("Submit"); ?>" /> <br />
             <label for="trace835"><?php echo xlt("Check No"); ?>:</label>
-            <input type="text" size=10 name="trace835" value="" />
+            <input type="text" class="form-control form-rounded" size=10 name="trace835" value="" />
             <input type="submit" name="subtrace835" value="<?php echo xla("Submit"); ?>" />
         </fieldset>
         </form> 
@@ -250,7 +249,7 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
                     <fieldset>
                         <legend><?php echo xlt("View Batch Claim x12 text"); ?>:</legend>
                         <label for="enctr"><?php echo xlt("Enter Encounter"); ?>:</label>
-                        <input type="text" name="enctrbatch" size=10 value="" /> 
+                        <input type="text" class="form-rounded form-control" name="enctrbatch" size=10 value="" /> 
                         <input type="submit" name="Batch-enctr" value="<?php echo xla("Submit"); ?>" />
                     </fieldset>
                 </form>
@@ -260,7 +259,7 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
                 <fieldset>
                     <legend><?php echo xlt("View ERA x12 text"); ?></legend>
                     <label for="enctrERA"><?php echo xlt("Enter Encounter"); ?>:</label>
-                    <input type="text" name="enctrEra" size=10 value="" />
+                    <input type="text" class="form-rounded form-control" name="enctrEra" size=10 value="" />
                     <input type="submit" name="eraText" value="<?php echo xla("Submit"); ?>" />
                 </fieldset>
                 </form>

--- a/interface/billing/era_payments.php
+++ b/interface/billing/era_payments.php
@@ -34,6 +34,8 @@ require_once($GLOBALS['OE_SITE_DIR'] . "/statement.inc.php");
 require_once("$srcdir/parse_era.inc.php");
 require_once("$srcdir/sl_eob.inc.php");
 require_once("$srcdir/formatting.inc.php");
+require_once("$srcdir/headers.inc.php");
+
 //===============================================================================
 // This is called back by parse_era() if we are processing X12 835's.
 $alertmsg = '';
@@ -85,7 +87,9 @@ $DateLocale = getLocaleCodeForDisplayLanguage($GLOBALS['language_default']);
 <head>
 <?php if (function_exists('html_header_show')) html_header_show(); ?>
 <link rel="stylesheet" href="../../library/css/jquery.datetimepicker.css">
-
+<?php
+  call_required_libraries(['bootstrap']);
+?>
 <link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/dialog.js"></script>
 
@@ -201,7 +205,7 @@ document.onclick=HideTheAjaxDivs;
       <tr>
         <td  align="left"  class="text"></td>
         <td  align="left"  class="text"><?php echo htmlspecialchars( xl('Date'), ENT_QUOTES).':' ?></td>
-        <td  align="left"  class="text"><input type='text' size='8' name='check_date' id='check_date' value="<?php echo formData('check_date') ?>"  class="class1 text " onKeyDown="PreventIt(event)" />
+        <td  align="left"  class="text"><input type='text' size='8' name='check_date' id='check_date' value="<?php echo formData('check_date') ?>"  class="class1 text form-control form-rounded" onKeyDown="PreventIt(event)" />
         
        <script>
            $(function() {
@@ -217,7 +221,7 @@ document.onclick=HideTheAjaxDivs;
       <tr>
         <td  align="left"  class="text"></td>
         <td  align="left"  class="text"><?php echo htmlspecialchars( xl('Post To Date'), ENT_QUOTES).':' ?></td>
-        <td  align="left"  class="text"><input type='text' size='8' name='post_to_date' id='post_to_date'  value="<?php echo formData('post_to_date') ?>" class="class1 text "   onKeyDown="PreventIt(event)"  />
+        <td  align="left"  class="text"><input type='text' size='8' name='post_to_date' id='post_to_date'  value="<?php echo formData('post_to_date') ?>" class="class1 text form-control form-rounded"   onKeyDown="PreventIt(event)"  />
        <script>
            $(function() {
                $("#post_to_date").datetimepicker({
@@ -231,7 +235,7 @@ document.onclick=HideTheAjaxDivs;
       <tr>
         <td  align="left"  class="text"></td>
         <td  align="left"  class="text"><?php echo htmlspecialchars( xl('Deposit Date'), ENT_QUOTES).':' ?></td>
-        <td  align="left"  class="text"><input type='text' size='8' name='deposit_date' id='deposit_date'  onKeyDown="PreventIt(event)"   class="text " value="<?php echo formData('deposit_date') ?>"    />
+        <td  align="left"  class="text"><input type='text' size='8' name='deposit_date' id='deposit_date'  onKeyDown="PreventIt(event)"   class="text form-control form-rounded" value="<?php echo formData('deposit_date') ?>"    />
        <script>
            $(function() {
                $("#deposit_date").datetimepicker({
@@ -252,7 +256,7 @@ document.onclick=HideTheAjaxDivs;
         <table width="335" border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td width="280">
-                <input type="hidden" id="hidden_ajax_close_value" value="<?php echo formData('type_code') ?>" /><input name='type_code'  id='type_code' class="text "
+                <input type="hidden" id="hidden_ajax_close_value" value="<?php echo formData('type_code') ?>" /><input name='type_code'  id='type_code' class="text form-control form-rounded"
                 style=" width:280px;"   onKeyDown="PreventIt(event)" value="<?php echo formData('type_code') ?>"  autocomplete="off"   /><br> 
                 <!--onKeyUp="ajaxFunction(event,'non','search_payments.php');"-->
                     <div id='ajax_div_insurance_section'>

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -41,6 +41,7 @@ require_once(dirname(__FILE__) . "/../../library/classes/X12Partner.class.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/formatting.inc.php");
 require_once("$srcdir/payment.inc.php");
+require_once("$srcdir/headers.inc.php");
 //===============================================================================
     $screen='new_payment';
 //===============================================================================
@@ -137,6 +138,10 @@ $DateFormat=DateFormatRead();
 
 <script type="text/javascript" src="../../library/textformat.js"></script>
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/dialog.js"></script>
+
+<?php
+  call_required_libraries(['bootstrap']);
+?>
 
 <?php include_once("{$GLOBALS['srcdir']}/payment_jav.inc.php"); ?>
 <script type="text/javascript" src="../../library/js/jquery-1.7.2.min.js"></script>
@@ -360,8 +365,8 @@ return false;
  if($payment_id*1>0)
   {
   ?>
-<table width="999" border="0" cellspacing="0" cellpadding="10" bgcolor="#DEDEDE"><tr><td>
-    <table width="979" border="0" cellspacing="0" cellpadding="0">
+<table style="width:'999px' border:'0px' cellspacing:'0px' cellpadding='10px'"><tr><td>
+    <table style="width:'979px' border:'0px' cellspacing:'0px' cellpadding:'0px'">
       <tr>
         <td colspan="13" align="left" >
                 <!--Distribute section-->

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -34,7 +34,7 @@ function generate_list_payment_category($tag_name, $list_id, $currvalue, $title,
   $s = '';
   $tag_name_esc = htmlspecialchars( $tag_name, ENT_QUOTES);
   $s .= "<select name='$tag_name_esc' id='$tag_name_esc'";
-  if ($class) $s .= " class='$class'";
+  if ($class) $s .= " class='$class form-control form-rounded'";
   if ($onchange) $s .= " onchange='$onchange'";
   $selectTitle = htmlspecialchars( $title, ENT_QUOTES);
   $s .= " title='$selectTitle'>";
@@ -185,7 +185,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
         <td align="left" class='text'></td>
         <td align="left" class='text'><?php echo htmlspecialchars( xl('Date'), ENT_QUOTES).':' ?></td>
         <td align="left" class="text" >
-            <input type='text' size='9' name='check_date' id='check_date' class="class1 text "
+            <input type='text' size='9' name='check_date' id='check_date' class="class1 text form-control form-rouded"
                    value="<?php echo htmlspecialchars(oeFormatShortDate($CheckDate));?>"/>
         </td>
         <td>
@@ -200,7 +200,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
         </td>
         <td></td>
         <td align="left" class='text'><?php echo htmlspecialchars( xl('Post To Date'), ENT_QUOTES).':' ?></td>
-        <td align="left" class="text"><input type='text' size='9' name='post_to_date' id='post_to_date' class="class1 text "   value="<?php echo $screen=='new_payment'?htmlspecialchars(oeFormatShortDate(date('Y-m-d'))):htmlspecialchars(oeFormatShortDate($PostToDate));?>"/></td>
+        <td align="left" class="text"><input type='text' size='9' name='post_to_date' id='post_to_date' class="class1 text form-control form-rouded"   value="<?php echo $screen=='new_payment'?htmlspecialchars(oeFormatShortDate(date('Y-m-d'))):htmlspecialchars(oeFormatShortDate($PostToDate));?>"/></td>
        <script>
                $(function() {
                    $("#post_to_date").datetimepicker({
@@ -236,7 +236,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
           $CheckDivDisplay='';
          }
         ?>
-        <input type="text" name="check_number"  style="width:140px;<?php echo $CheckDisplay;?>"  autocomplete="off"  value="<?php echo htmlspecialchars($CheckNumber);?>"  onKeyUp="ConvertToUpperCase(this)"  id="check_number"  class="text "   />
+        <input type="text" name="check_number"  style="width:140px;<?php echo $CheckDisplay;?>"  autocomplete="off"  value="<?php echo htmlspecialchars($CheckNumber);?>"  onKeyUp="ConvertToUpperCase(this)"  id="check_number"  class="text form-control form-rouded"   />
         <div  id="div_check_number" class="text"  style="border:1px solid black; width:140px;<?php echo $CheckDivDisplay;?>">&nbsp;</div>
        </td>
        </tr>
@@ -246,7 +246,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
       <tr>
         <td align="left" class="text"></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Payment Amount'), ENT_QUOTES).':' ?></td>
-        <td align="left"><input   type="text" name="payment_amount"   autocomplete="off"  id="payment_amount"  onchange="ValidateNumeric(this);<?php echo $screen=='new_payment'?'FillUnappliedAmount();':'FillAmount();';?>"  value="<?php echo $screen=='new_payment'?htmlspecialchars('0.00'):htmlspecialchars($PayTotal);?>"  style="text-align:right"    class="class1 text "   /></td>
+        <td align="left"><input   type="text" name="payment_amount"   autocomplete="off"  id="payment_amount"  onchange="ValidateNumeric(this);<?php echo $screen=='new_payment'?'FillUnappliedAmount();':'FillAmount();';?>"  value="<?php echo $screen=='new_payment'?htmlspecialchars('0.00'):htmlspecialchars($PayTotal);?>"  style="text-align:right"    class="class1 text form-control form-rouded"   /></td>
         <td align="left" ></td>
         <td align="left" ></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Paying Entity'), ENT_QUOTES).':' ?></td>
@@ -280,7 +280,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
       <tr>
         <td align="left" class="text"></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Payment From'), ENT_QUOTES).':' ?></td>
-        <td align="left" colspan="5"><input type="hidden" id="hidden_ajax_close_value" value="<?php echo htmlspecialchars($div_after_save);?>" /><input name='type_code'  id='type_code' class="text "  style="width:369px"   onKeyDown="PreventIt(event)"  value="<?php echo htmlspecialchars($div_after_save);?>"  autocomplete="off"   /><br>
+        <td align="left" colspan="5"><input type="hidden" id="hidden_ajax_close_value" value="<?php echo htmlspecialchars($div_after_save);?>" /><input name='type_code'  id='type_code' class="text form-control form-rouded"  style="width:369px"   onKeyDown="PreventIt(event)"  value="<?php echo htmlspecialchars($div_after_save);?>"  autocomplete="off"   /><br>
         <!-- onKeyUp="ajaxFunction(event,'non','edit_payment.php');" -->
          <div id='ajax_div_insurance_section'>
           <div id='ajax_div_insurance_error'>
@@ -297,7 +297,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
         <td align="left" class='text'></td>
         <td align="left" class='text'><?php echo htmlspecialchars( xl('Deposit Date'), ENT_QUOTES).':' ?></td>
         <td align="left">
-            <input type='text' size='9' name='deposit_date' id='deposit_date' class="class1 text "
+            <input type='text' size='9' name='deposit_date' id='deposit_date' class="class1 text form-control form-rouded"
                    value="<?php echo htmlspecialchars(oeFormatShortDate($DepositDate));?>"/>
         </td>
         <td>
@@ -313,7 +313,7 @@ if(($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && $
         </td>
         <td></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Description'), ENT_QUOTES).':' ?></td>
-        <td colspan="6" align="left"><input type="text" name="description"  id="description"   onKeyDown="PreventIt(event)"   value="<?php echo htmlspecialchars($Description);?>"   style="width:396px" class="text "   /></td>
+        <td colspan="6" align="left"><input type="text" name="description"  id="description"   onKeyDown="PreventIt(event)"   value="<?php echo htmlspecialchars($Description);?>"   style="width:396px" class="text form-control form-rouded"   /></td>
         <td align="left" class="text"><font  style="font-size:11px"><?php echo htmlspecialchars( xl('UNDISTRIBUTED'), ENT_QUOTES).':' ?></font><input name="HidUnappliedAmount" id="HidUnappliedAmount"  value="<?php echo ($UndistributedAmount*1==0)? htmlspecialchars("0.00") : htmlspecialchars(number_format($UndistributedAmount,2,'.',','));?>" type="hidden"/><input name="HidUnpostedAmount" id="HidUnpostedAmount"  value="<?php echo htmlspecialchars($UndistributedAmount); ?>" type="hidden"/><input name="HidCurrentPostedAmount" id="HidCurrentPostedAmount"  value="" type="hidden"/></td>
         <td align="left" class="text"><div  id="TdUnappliedAmount" class="text"  style="border:1px solid black; width:75px; background-color:#EC7676; padding-left:5px;"><?php echo ($UndistributedAmount*1==0)? htmlspecialchars("0.00") : htmlspecialchars(number_format($UndistributedAmount,2,'.',','));?></div></td>
         </tr>

--- a/interface/billing/search_payments.php
+++ b/interface/billing/search_payments.php
@@ -39,6 +39,7 @@ require_once(dirname(__FILE__) . "/../../library/classes/X12Partner.class.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/formatting.inc.php");
 require_once("$srcdir/payment.inc.php");
+require_once("$srcdir/headers.inc.php");
 //===============================================================================
 //Deletion of payment and its corresponding distributions.
 //===============================================================================
@@ -378,6 +379,9 @@ document.onclick=HideTheAjaxDivs;
 .left{border-left:1px solid black;}
 .right{border-right:1px solid black;}
 </style>
+<?php
+  call_required_libraries(['bootstrap']);
+?>
 </head>
 <body class="body_top" onLoad="OnloadAction()">
 <form name='new_payment' method='post'  style="display:inline" >
@@ -432,7 +436,7 @@ document.onclick=HideTheAjaxDivs;
                 <table  border="0" cellspacing="0" cellpadding="0">
                   <tr>
                     <td align="left" class="text"><?php echo htmlspecialchars( xl('From'), ENT_QUOTES).':' ?></td>
-                    <td><input type='text'  style="width:90px;" name='FromDate' id='FromDate' class="text" value='<?php echo attr($FromDate); ?>' />
+                    <td><input type='text'  style="width:90px;" name='FromDate' id='FromDate' class="text form-control form-rounded" value='<?php echo attr($FromDate); ?>' />
                        <script>
                            $(function() {
                                $("#FromDate").datetimepicker({
@@ -443,7 +447,7 @@ document.onclick=HideTheAjaxDivs;
                        </script></td>
                     <td width="53">&nbsp;</td>
                     <td align="left" class="text"><?php echo htmlspecialchars( xl('To'), ENT_QUOTES).':' ?></td>
-                    <td><input type='text'  style="width:103px;"  name='ToDate' id='ToDate' class="text" value='<?php echo attr($ToDate); ?>' />
+                    <td><input type='text'  style="width:103px;"  name='ToDate' id='ToDate' class="text form-control form-rounded" value='<?php echo attr($ToDate); ?>' />
                        <script>
                            $(function() {
                                $("#ToDate").datetimepicker({
@@ -461,12 +465,12 @@ document.onclick=HideTheAjaxDivs;
         <td align="left"><?php  echo generate_select_list("payment_method", "payment_method", "$PaymentMethod", "Payment Method"," ","class1 text");?></td>
         <td></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Check Number'), ENT_QUOTES).':' ?></td>
-        <td><input type="text" name="check_number"   autocomplete="off"  value="<?php echo htmlspecialchars(formData('check_number'));?>"  id="check_number"  class=" class1 text "   /></td>
+        <td><input type="text" name="check_number"   autocomplete="off"  value="<?php echo htmlspecialchars(formData('check_number'));?>"  id="check_number"  class=" class1 text form-control form-rounded"   /></td>
           </tr>
           <tr>
             <td align="right"></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Payment Amount'), ENT_QUOTES).':' ?></td>
-        <td align="left"><input   type="text" name="payment_amount"   autocomplete="off"  id="payment_amount" onKeyUp="ValidateNumeric(this);"  value="<?php echo htmlspecialchars(formData('payment_amount'));?>"  style="text-align:right"    class="class1 text "   /></td>
+        <td align="left"><input   type="text" name="payment_amount"   autocomplete="off"  id="payment_amount" onKeyUp="ValidateNumeric(this);"  value="<?php echo htmlspecialchars(formData('payment_amount'));?>"  style="text-align:right"    class="class1 text form-control form-rounded"   /></td>
         <td align="left" ></td>
         <td align="left" class="text"><?php echo htmlspecialchars( xl('Paying Entity'), ENT_QUOTES).':' ?></td>
         <td align="left"><?php  echo generate_select_list("type_name", "payment_type", "$type_name","Paying Entity"," ","class1 text","SearchPayingEntityAction()");?>     </td>
@@ -485,7 +489,7 @@ document.onclick=HideTheAjaxDivs;
             <table width="335" border="0" cellspacing="0" cellpadding="0">
               <tr>
                 <td width="280">
-                <input type="hidden" id="hidden_ajax_close_value" value="<?php echo htmlspecialchars($div_after_save);?>" /><input name='type_code'  id='type_code' class="text "
+                <input type="hidden" id="hidden_ajax_close_value" value="<?php echo htmlspecialchars($div_after_save);?>" /><input name='type_code'  id='type_code' class="text form-control form-rounded"
                 style=" width:280px;"   onKeyDown="PreventIt(event)" value="<?php echo htmlspecialchars($div_after_save);?>"  autocomplete="off"   /><br> 
                 <!--onKeyUp="ajaxFunction(event,'non','search_payments.php');"-->
                     <div id='ajax_div_insurance_section'>

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -38,6 +38,7 @@ require_once("$srcdir/options.inc.php");
 require_once("$srcdir/acl.inc");
 require_once("$srcdir/classes/Document.class.php");
 require_once("$srcdir/classes/Note.class.php");
+require_once("$srcdir/headers.inc.php");
 
 $DEBUG = 0; // set to 0 for production, 1 to test
 
@@ -405,6 +406,10 @@ if (($_POST['form_print'] || $_POST['form_download'] || $_POST['form_pdf']) || $
 <title><?php xl('EOB Posting - Search','e'); ?></title>
 <script type="text/javascript" src="../../library/textformat.js"></script>
 
+<?php
+  call_required_libraries(['bootstrap']);
+?>
+
 <script language="JavaScript">
 
 var mypcc = '1';
@@ -432,7 +437,7 @@ function npopup(pid) {
 
 <form method='post' action='sl_eob_search.php' enctype='multipart/form-data'>
 
-<table border='0' cellpadding='5' cellspacing='0'>
+<table style="border-collapse: separate; border: 0px; border-spacing: 5px; padding: 5px;">
  <tr>
 
 <?php
@@ -442,7 +447,7 @@ function npopup(pid) {
   echo "  </td>\n";
   echo "  <td>\n";
   $insurancei = getInsuranceProviders();
-  echo "   <select name='form_payer_id'>\n";
+  echo "   <select class='form-control form-rounded' name='form_payer_id'>\n";
   echo "    <option value='0'>-- " . xl('Patient') . " --</option>\n";
   foreach ($insurancei as $iid => $iname) {
     echo "<option value='$iid'";
@@ -457,14 +462,14 @@ function npopup(pid) {
    <?php xl('Source:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_source' size='10' value='<?php echo $_POST['form_source']; ?>'
+   <input  type='text' class='form-control form-rounded' name='form_source' size='10' value='<?php echo $_POST['form_source']; ?>'
     title='<?php xl("A check number or claim number to identify the payment","e"); ?>'>
   </td>
   <td>
    <?php xl('Pay Date:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_paydate' size='10' value='<?php echo $_POST['form_paydate']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_paydate' size='10' value='<?php echo $_POST['form_paydate']; ?>'
     onkeyup='datekeyup(this,mypcc)' onblur='dateblur(this,mypcc)'
     title='<?php xl("Date of payment yyyy-mm-dd","e"); ?>'>
   </td>
@@ -473,7 +478,7 @@ function npopup(pid) {
    <?php xl('Deposit Date:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_deposit_date' size='10' value='<?php echo $_POST['form_deposit_date']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_deposit_date' size='10' value='<?php echo $_POST['form_deposit_date']; ?>'
     onkeyup='datekeyup(this,mypcc)' onblur='dateblur(this,mypcc)'
     title='<?php xl("Date of bank deposit yyyy-mm-dd","e"); ?>'>
   </td>
@@ -482,7 +487,7 @@ function npopup(pid) {
    <?php xl('Amount:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_amount' size='10' value='<?php echo $_POST['form_amount']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_amount' size='10' value='<?php echo $_POST['form_amount']; ?>'
     title='<?php xl("Paid amount that you will allocate","e"); ?>'>
   </td>
   <td align='right'>
@@ -492,46 +497,46 @@ function npopup(pid) {
  </tr>
 </table>
 
-<table border='0' cellpadding='5' cellspacing='0'>
+<table  style="border-collapse: separate; border: 0px; border-spacing: 5px; padding: 5px;">
 
- <tr bgcolor='#ddddff'>
+ <tr>
   <td>
    <?php xl('Name:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_name' size='10' value='<?php echo $_POST['form_name']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_name' size='10' value='<?php echo $_POST['form_name']; ?>'
     title='<?php xl("Any part of the patient name, or \"last,first\", or \"X-Y\"","e"); ?>'>
   </td>
   <td>
    <?php xl('Chart ID:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_pid' size='10' value='<?php echo $_POST['form_pid']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_pid' size='10' value='<?php echo $_POST['form_pid']; ?>'
     title='<?php xl("Patient chart ID","e"); ?>'>
   </td>
   <td>
    <?php xl('Encounter:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_encounter' size='10' value='<?php echo $_POST['form_encounter']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_encounter' size='10' value='<?php echo $_POST['form_encounter']; ?>'
     title='<?php xl("Encounter number","e"); ?>'>
   </td>
   <td>
    <?php xl('Svc Date:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_date' size='10' value='<?php echo $_POST['form_date']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_date' size='10' value='<?php echo $_POST['form_date']; ?>'
     title='<?php xl("Date of service mm/dd/yyyy","e"); ?>'>
   </td>
   <td>
    <?php xl('To:','e'); ?>
   </td>
   <td>
-   <input type='text' name='form_to_date' size='10' value='<?php echo $_POST['form_to_date']; ?>'
+   <input type='text' class='form-control form-rounded' name='form_to_date' size='10' value='<?php echo $_POST['form_to_date']; ?>'
     title='<?php xl("Ending DOS mm/dd/yyyy if you wish to enter a range","e"); ?>'>
   </td>
   <td>
-   <select name='form_category'>
+   <select name='form_category' class='form-control form-rounded'>
 <?php
  foreach (array(xl('Open'), xl('All'), xl('Due Pt'), xl('Due Ins')) as $value) {
   echo "    <option value='$value'";
@@ -547,7 +552,7 @@ function npopup(pid) {
  </tr>
 
  <!-- Support for X12 835 upload -->
- <tr bgcolor='#ddddff'>
+ <tr>
   <td colspan='12'>
    <?php xl('Or upload ERA file:','e'); ?>
    <input type="hidden" name="MAX_FILE_SIZE" value="5000000" />

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -112,7 +112,7 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 
     if ($class) {
                 $class_esc = attr($class);
-        $s .= " class='$class_esc'";
+        $s .= " class='$class_esc form-control form-rounded'";
     }
     if ($onchange) {
         $s .= " onchange='$onchange'";

--- a/sites/default/edi/history/csv/claims_277.csv
+++ b/sites/default/edi/history/csv/claims_277.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,Status,st_277,File_277,payer_name,claim_id,bht03_837

--- a/sites/default/edi/history/csv/claims_997.csv
+++ b/sites/default/edi/history/csv/claims_997.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,Status,ak_num,File_997,Ctn_837,err_seg

--- a/sites/default/edi/history/csv/claims_batch.csv
+++ b/sites/default/edi/history/csv/claims_batch.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,InsLevel,Ctn_837,File_837,Fee,PtPaid,Provider

--- a/sites/default/edi/history/csv/claims_dpr.csv
+++ b/sites/default/edi/history/csv/claims_dpr.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,Status,Batch,FileName,Payer

--- a/sites/default/edi/history/csv/claims_ebr.csv
+++ b/sites/default/edi/history/csv/claims_ebr.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,Status,Batch,FileName,Payer

--- a/sites/default/edi/history/csv/claims_era.csv
+++ b/sites/default/edi/history/csv/claims_era.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,Status,trace,File_835,claimID,Pmt,PtResp,Payer

--- a/sites/default/edi/history/csv/claims_ibr.csv
+++ b/sites/default/edi/history/csv/claims_ibr.csv
@@ -1,0 +1,1 @@
+PtName,SvcDate,clm01,Status,Batch,FileName,Payer

--- a/sites/default/edi/history/csv/files_277.csv
+++ b/sites/default/edi/history/csv/files_277.csv
@@ -1,0 +1,1 @@
+Date,FileName,Ctn_277,Accept,AccAmt,Reject,RejAmt

--- a/sites/default/edi/history/csv/files_997.csv
+++ b/sites/default/edi/history/csv/files_997.csv
@@ -1,0 +1,1 @@
+Date,FileName,Ctn_999,ta1ctrl,RejCt

--- a/sites/default/edi/history/csv/files_batch.csv
+++ b/sites/default/edi/history/csv/files_batch.csv
@@ -1,0 +1,1 @@
+Date,FileName,Ctn_837,claim_ct,x12_partner

--- a/sites/default/edi/history/csv/files_ebr.csv
+++ b/sites/default/edi/history/csv/files_ebr.csv
@@ -1,0 +1,1 @@
+Date,FileName,clrhsid,claim_ct,reject_ct,Batch

--- a/sites/default/edi/history/csv/files_era.csv
+++ b/sites/default/edi/history/csv/files_era.csv
@@ -1,0 +1,1 @@
+Date,FileName,Trace,claim_ct,Denied,Payer


### PR DESCRIPTION
Fixes #877 

Bootstrap was added to most of the elements of these pages.

Simply adding bootstrap to the required elements would mess up the whole page. To avoid that, several workarounds were made like the addition of styles and breaklines. Adding bootstrap on files like these is not easy. There are a lot of properties that were deprecated in HTML5 that were still there. I wrote an equivalent style for those I've caught.

Couldn't do my best because the way those tables were coded there wasn't much to do.

**My opinion:** I personally don't like bootstrap because it limits us. Several inputs could have _padding: 0px_ and would appear much more stylish but I'm restricted to bootstrap styles. Anyway, I did it but my advice for the whole project is: don't try to insert bootstrap in a platform that wasn't originally designed with bootstrap. It brings a lot of problems. The best way to redesign the whole thing would be to make our own styles. 