### PR TITLE
Deleted duplicated colon in "windows" header - README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Code contributions are very welcome! Browse the [Issue tracker](https://github.c
 
 For detailed and step-by-step Installation Instructions refer to [Installation Instructions](/INSTALL.md)
 
-## Windows :: 
+## Windows : 
 
 First off, make sure that you have the [WAMP](http://www.wampserver.com/en/) or [XAMPP](https://www.apachefriends.org/index.html) server installed and that the time zone is set correctly.
 


### PR DESCRIPTION
I deleted duplicated colon in readme.</br>

![colon](https://user-images.githubusercontent.com/25907897/34461181-2f62366e-ee24-11e7-85bb-0224daef0b5a.png)
