### PR TITLE
Solution for missing logo in printable versions of reports issue #962

### DIFF
--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -375,11 +375,11 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
           echo ' ' . xl('on') . ' ' . oeFormatShortDate(substr($enrow['date'], 0, 10));
         ?>
       </p>
-    <div class="container">
+
       <center>
         <p>
-          <table class="table" id='proctable'>
-            <tr style="background-color: rgba(56, 193, 228, 0.5)">
+          <table class="table table-hover table-bordered" width='95%' id='proctable'>
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Ordering Provider','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -389,7 +389,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr style="background-color: rgba(57, 128, 235, 0.5)">
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Sending To','e'); ?>:</b></td>
               <td valign='top'>
                 <select class='form-control' style='width: auto;' name='form_lab_id' onchange='lab_id_changed()'>
@@ -406,7 +406,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr style="background-color: rgba(56, 193, 228, 0.5)">
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Order Date','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -424,7 +424,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr style="background-color: rgba(57, 128, 235, 0.5)">
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Internal Time Collected','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -442,7 +442,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr style="background-color: rgba(56, 193, 228, 0.5)">
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Priority','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -452,7 +452,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr style="background-color: rgba(57, 128, 235, 0.5)">
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Status','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -462,14 +462,17 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr style="background-color: rgba(56, 193, 228, 0.5)">
+            <tr>
               <td width='1%' valign='top' nowrap><b><?php xl('Clinical History','e'); ?>:</b></td>
               <td valign='top'>
-              <div class="form-group">
-                  <textarea class="form-control" rows="3" maxlength="255" name="form_clinical_hx">
-                    <?php echo attr($row['clinical_hx']); ?>   
-                  </textarea>
-              </div>
+               <input
+                type='text'
+                maxlength='255'
+                name='form_clinical_hx'
+                style='width:100%'
+                class='inputtext form-control'
+                value='<?php echo attr($row['clinical_hx']); ?>'
+               />
               </td>
             </tr>
 
@@ -533,7 +536,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
                 $ptid = $oprow['procedure_type_id'];
               }
           ?>
-            <tr style="background-color: rgba(57, 128, 235, 0.5)">
+            <tr>
             <!--<td width='1%' valign='top'><b>
             <?php echo xl('Procedure') . ' ' . ($i + 1); ?>:</b></td>-->
             <?php if(empty($formid) || empty($oprow['procedure_order_title'])) {?> 
@@ -569,7 +572,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
                 />
               </td>
             </tr>
-            <tr style="background-color: rgba(56, 193, 228, 0.5)">
+            <tr>
               <td valign='top'> 
                 <input
                   type='hidden'
@@ -648,7 +651,6 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
         </p>
 
       </center>
-    </div>
 
       <link rel="stylesheet" href="../../../library/css/jquery.datetimepicker.css">
       <script type="text/javascript" src="../../../library/js/jquery.datetimepicker.full.min.js"></script>

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -375,11 +375,11 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
           echo ' ' . xl('on') . ' ' . oeFormatShortDate(substr($enrow['date'], 0, 10));
         ?>
       </p>
-
+    <div class="container">
       <center>
         <p>
-          <table class="table table-hover table-bordered" width='95%' id='proctable'>
-            <tr>
+          <table class="table" id='proctable'>
+            <tr style="background-color: rgba(56, 193, 228, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Ordering Provider','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -389,7 +389,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr>
+            <tr style="background-color: rgba(57, 128, 235, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Sending To','e'); ?>:</b></td>
               <td valign='top'>
                 <select class='form-control' style='width: auto;' name='form_lab_id' onchange='lab_id_changed()'>
@@ -406,7 +406,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr>
+            <tr style="background-color: rgba(56, 193, 228, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Order Date','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -424,7 +424,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr>
+            <tr style="background-color: rgba(57, 128, 235, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Internal Time Collected','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -442,7 +442,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr>
+            <tr style="background-color: rgba(56, 193, 228, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Priority','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -452,7 +452,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr>
+            <tr style="background-color: rgba(57, 128, 235, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Status','e'); ?>:</b></td>
               <td valign='top'>
                 <?php
@@ -462,17 +462,14 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
               </td>
             </tr>
 
-            <tr>
+            <tr style="background-color: rgba(56, 193, 228, 0.5)">
               <td width='1%' valign='top' nowrap><b><?php xl('Clinical History','e'); ?>:</b></td>
               <td valign='top'>
-               <input
-                type='text'
-                maxlength='255'
-                name='form_clinical_hx'
-                style='width:100%'
-                class='inputtext form-control'
-                value='<?php echo attr($row['clinical_hx']); ?>'
-               />
+              <div class="form-group">
+                  <textarea class="form-control" rows="3" maxlength="255" name="form_clinical_hx">
+                    <?php echo attr($row['clinical_hx']); ?>   
+                  </textarea>
+              </div>
               </td>
             </tr>
 
@@ -536,7 +533,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
                 $ptid = $oprow['procedure_type_id'];
               }
           ?>
-            <tr>
+            <tr style="background-color: rgba(57, 128, 235, 0.5)">
             <!--<td width='1%' valign='top'><b>
             <?php echo xl('Procedure') . ' ' . ($i + 1); ?>:</b></td>-->
             <?php if(empty($formid) || empty($oprow['procedure_order_title'])) {?> 
@@ -572,7 +569,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
                 />
               </td>
             </tr>
-            <tr>
+            <tr style="background-color: rgba(56, 193, 228, 0.5)">
               <td valign='top'> 
                 <input
                   type='hidden'
@@ -651,6 +648,7 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
         </p>
 
       </center>
+    </div>
 
       <link rel="stylesheet" href="../../../library/css/jquery.datetimepicker.css">
       <script type="text/javascript" src="../../../library/js/jquery.datetimepicker.full.min.js"></script>

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -483,18 +483,7 @@ if ($printable) {
   // in HTML view it's just one line at the top of page 1
   echo '<page_header style="text-align:right;" class="custom-tag"> ' . xlt("PATIENT") . ':' . text($titleres['lname']) . ', ' . text($titleres['fname']) . ' - ' . $titleres['DOB_TS'] . '</page_header>    ';
   echo '<page_footer style="text-align:right;" class="custom-tag">' . xlt('Generated on') . ' ' . oeFormatShortDate() . ' - ' . text($facility['name']) . ' ' . text($facility['phone']) . '</page_footer>';
-
-  //use logo if it exists in directory
-  if (file_exists("$OE_SITE_DIR/images/practice_logo.png"))  $practice_logo = "$OE_SITE_DIR/images/practice_logo.png";
-  else if (file_exists("$OE_SITE_DIR/images/practice_logo.gif"))  $practice_logo = "$OE_SITE_DIR/images/practice_logo.gif";
-  else if (file_exists("$OE_SITE_DIR/images/practice_logo.jpg"))  $practice_logo = "$OE_SITE_DIR/images/practice_logo.jpg";
-  else if (file_exists("$OE_SITE_DIR/images/practice_logo.jpeg")) $practice_logo =  "$OE_SITE_DIR/images/practice_logo.jpeg";
-  else $practice_logo = '';
-   $dir = explode('/', $practice_logo) ;
-   $practice_logo = "$dir[4]/$dir[5]/$dir[6]/$dir[7]/$dir[8]" ;
-   if ($practice_logo) {
-        echo "<img src='../../../../$practice_logo' align='left' style='width : 56px ; height : 90.6px'><br />\n";
-   }
+  
 ?>
 <h2><?php echo $facility['name'] ?></h2>
 <?php echo $facility['street'] ?><br>

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -484,12 +484,7 @@ if ($printable) {
   echo '<page_header style="text-align:right;" class="custom-tag"> ' . xlt("PATIENT") . ':' . text($titleres['lname']) . ', ' . text($titleres['fname']) . ' - ' . $titleres['DOB_TS'] . '</page_header>    ';
   echo '<page_footer style="text-align:right;" class="custom-tag">' . xlt('Generated on') . ' ' . oeFormatShortDate() . ' - ' . text($facility['name']) . ' ' . text($facility['phone']) . '</page_footer>';
 
-  // Use logo if it exists as 'practice_logo.png' in the site dir
-  // old code used the global custom dir which is no longer a valid
-   $practice_logo = "$OE_SITE_DIR/images/practice_logo.png";
-   if (file_exists($practice_logo)) {
-        echo "<img src='$practice_logo' align='left'><br />\n";
-     } 
+  echo "<img src='../../../sites/default/images/practice_logo.png' align='left' style='width : 45px ; height : 56px'><br>";
 ?>
 <h2><?php echo $facility['name'] ?></h2>
 <?php echo $facility['street'] ?><br>

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -484,7 +484,17 @@ if ($printable) {
   echo '<page_header style="text-align:right;" class="custom-tag"> ' . xlt("PATIENT") . ':' . text($titleres['lname']) . ', ' . text($titleres['fname']) . ' - ' . $titleres['DOB_TS'] . '</page_header>    ';
   echo '<page_footer style="text-align:right;" class="custom-tag">' . xlt('Generated on') . ' ' . oeFormatShortDate() . ' - ' . text($facility['name']) . ' ' . text($facility['phone']) . '</page_footer>';
 
-  echo "<img src='../../../sites/default/images/practice_logo.png' align='left' style='width : 56px ; height : 90.6px'><br>";
+  //use logo if it exists in directory
+  if (file_exists("$OE_SITE_DIR/images/practice_logo.png"))  $practice_logo = "$OE_SITE_DIR/images/practice_logo.png";
+  else if (file_exists("$OE_SITE_DIR/images/practice_logo.gif"))  $practice_logo = "$OE_SITE_DIR/images/practice_logo.gif";
+  else if (file_exists("$OE_SITE_DIR/images/practice_logo.jpg"))  $practice_logo = "$OE_SITE_DIR/images/practice_logo.jpg";
+  else if (file_exists("$OE_SITE_DIR/images/practice_logo.jpeg")) $practice_logo =  "$OE_SITE_DIR/images/practice_logo.jpeg";
+  else $practice_logo = '';
+   $dir = explode('/', $practice_logo) ;
+   $practice_logo = "$dir[4]/$dir[5]/$dir[6]/$dir[7]/$dir[8]" ;
+   if ($practice_logo) {
+        echo "<img src='../../../../$practice_logo' align='left' style='width : 56px ; height : 90.6px'><br />\n";
+   }
 ?>
 <h2><?php echo $facility['name'] ?></h2>
 <?php echo $facility['street'] ?><br>

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -484,7 +484,7 @@ if ($printable) {
   echo '<page_header style="text-align:right;" class="custom-tag"> ' . xlt("PATIENT") . ':' . text($titleres['lname']) . ', ' . text($titleres['fname']) . ' - ' . $titleres['DOB_TS'] . '</page_header>    ';
   echo '<page_footer style="text-align:right;" class="custom-tag">' . xlt('Generated on') . ' ' . oeFormatShortDate() . ' - ' . text($facility['name']) . ' ' . text($facility['phone']) . '</page_footer>';
 
-  echo "<img src='../../../sites/default/images/practice_logo.png' align='left' style='width : 45px ; height : 56px'><br>";
+  echo "<img src='../../../sites/default/images/practice_logo.png' align='left' style='width : 56px ; height : 90.6px'><br>";
 ?>
 <h2><?php echo $facility['name'] ?></h2>
 <?php echo $facility['street'] ?><br>


### PR DESCRIPTION
Logo was not previewed in the printable version of report

Before
![35188139-c8653818-fe30-11e7-8a07-44d9b95e0064](https://user-images.githubusercontent.com/30211121/35192889-2ea12422-fec0-11e7-9e74-8816317f64ce.jpg)

Now
![screenshot from 2018-01-21 18-15-38](https://user-images.githubusercontent.com/30211121/35192890-3636032e-fec0-11e7-855f-52e133bd89bf.png)

As you can see I have reduced the size of image to 56px by 45px because without this the result was

![screenshot from 2018-01-21 21-06-29](https://user-images.githubusercontent.com/30211121/35192927-e284ebb8-fec0-11e7-927c-542b51836ce2.png)
