### PR TITLE
Fix for #882

### DIFF
--- a/interface/main/tabs/templates/tabs_template.php
+++ b/interface/main/tabs/templates/tabs_template.php
@@ -5,7 +5,6 @@
         <!--ko if:!locked() -->
             <span class="tabSpan tabFloat bgcolor2">
                 <span  data-bind="text: title, click: tabClicked, css: {tabHidden: !visible()}"></span>
-                <span class="fa fa-refresh tab-button" data-bind="click: tabRefresh" title="Refresh"></span>
                     <!--ko if:!locked() -->
                         <span class="fa fa-unlock tab-button"  data-bind="click: tabLockToggle" title="Unlock"></span>
                     <!-- /ko -->
@@ -27,7 +26,7 @@
 
     <!-- ko  foreach: tabs.tabsList -->
         <div class="frameDisplay" data-bind="visible:visible">
-          
+
             <div class="body_title tabControls">
                 <span class="tabSpan bgcolor2">
                     <span  data-bind="text: title, click: tabClicked, css: {tabHidden: !visible()}"></span>
@@ -44,7 +43,7 @@
                     <!-- /ko -->
                 </span>
             </div>
-          
+
             <iframe data-bind="location: $data, iframeName: $data.name, ">
 
             </iframe>


### PR DESCRIPTION
Fixes #882 
Removed the refresh icon from tabs when in locked/ hidden state.

Tabs UI when locked:
![bef](https://user-images.githubusercontent.com/25399108/37542466-4f74ae00-2984-11e8-979b-e102ae6a3478.JPG)

Tabs UI when unlocked:
![af](https://user-images.githubusercontent.com/25399108/37542478-5a8a5c0e-2984-11e8-9699-c3071c1c3e2d.JPG)

@aethelwulffe @teryhill Please have a look.