### PR TITLE
Fix for #858: Log the reasons statements did not print. 

### DIFF
--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -428,29 +428,29 @@ if ($_POST['form_portalnotify']) {
     $reason = "\n\n";
     if ($countCase1 != 0) {
       //reason for case 1
-      $reason .= $countCase1 . " SELECTED STATEMENTS NOT PRINTED: ";
+      $reason .= $countCase1 . " SELECTED STATEMENT(S) NOT PRINTED: ";
       $reason .= "Statement amount value less than minimum amount value to print.";
       $reason .= "\n  PATIENT NAMES: ";
       foreach ($GLOBALS['pat_below_minimum_amount'] as $pat_name) {
-        $reason .= "{$pat_name}  ";
+        $reason .= "{$pat_name} | ";
       }
     }
     if ($countCase2 != 0) {
       //reason for case 2
-      $reason .= "\n\n" . $countCase2 . " SELECTED STATEMENTS NOT PRINTED: ";
+      $reason .= "\n\n" . $countCase2 . " SELECTED STATEMENT(S) NOT PRINTED: ";
       $reason .= "The patient is set to no statement";
       $reason .= "\n  PATIENT NAMES: ";
       foreach ($GLOBALS['pat_set_no_stmt'] as $pat_name) {
-        $reason .= "{$pat_name}  ";
+        $reason .= "{$pat_name} | ";
       }
     }
     if ($countCase3 != 0) {
       //reason for case 3
-      $reason .= "\n\n" . $countCase3 . " SELECTED STATEMENTS NOT PRINTED: ";
+      $reason .= "\n\n" . $countCase3 . " SELECTED STATEMENT(S) NOT PRINTED: ";
       $reason .= "The insurance company does not allow statements";
       $reason .= "\n  PATIENT NAMES: ";
       foreach ($GLOBALS['pat_not_allowed_insurance_company'] as $pat_name) {
-        $reason .= "{$pat_name}  ";
+        $reason .= "{$pat_name} | ";
       }
     }
     fwrite($fhprint, $reason);

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -420,15 +420,22 @@ if ($_POST['form_portalnotify']) {
     $countCase1 = (string)$GLOBALS['stmts_below_minimum_amount'];
     $countCase2 = (string)$GLOBALS['stmts_set_no_patient'];
     $countCase3 = (string)$GLOBALS['stmts_not_allowed_insurance_company'];
-    //reason for case 1
-    $reason = "/n/n" . $countCase1 . " SELECTED STATEMENTS NOT PRINTED: ";
-    $reason .= "Statement amount value less than minimum amount value to print.";
-    //reason for case 2
-    $reason .= "/n/n" . $countCase2 . " SELECTED STATEMENTS NOT PRINTED: ";
-    $reason .= "The patient is set to no statement";
-    //reason for case 3
-    $reason .= "/n/n" . $countCase3 . " SELECTED STATEMENTS NOT PRINTED: ";
-    $reason .= "The insurance company does not allow statements";
+    $reason = "\n\n";
+    if ($countCase1 != 0) {
+      //reason for case 1
+      $reason .= $countCase1 . " SELECTED STATEMENTS NOT PRINTED: ";
+      $reason .= "Statement amount value less than minimum amount value to print.";
+    }
+    if ($countCase2 != 0) {
+      //reason for case 2
+      $reason .= "\n\n" . $countCase2 . " SELECTED STATEMENTS NOT PRINTED: ";
+      $reason .= "The patient is set to no statement";
+    }
+    if ($countCase3 != 0) {
+      //reason for case 3
+      $reason .= "\n\n" . $countCase3 . " SELECTED STATEMENTS NOT PRINTED: ";
+      $reason .= "The insurance company does not allow statements";
+    }
     fwrite($fhprint, $reason);
     fclose($fhprint);
     sleep(1);

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -234,7 +234,9 @@ $today = date("Y-m-d");
   // Print or download statements if requested.
   //
 if (($_POST['form_print'] || $_POST['form_download'] || $_POST['form_pdf'] || $_POST['form_portalnotify']) && $_POST['form_cb']) {
-
+    //global variable to keep count of statements ignored
+    //ignored statements have amount value less than minimum amount to print
+    $GLOBALS['stmts_below_minimum_amount'] = 0;
     $fhprint = fopen($STMT_TEMP_FILE, 'w');
     $sqlBindArray = array();
     $where = "";
@@ -408,6 +410,11 @@ if ($_POST['form_portalnotify']) {
 
     if (!empty($stmt)) ++$stmt_count;
     fwrite($fhprint, make_statement($stmt));
+    //logging the reason for not printing some statements
+    $ignoredstmts = (string)$GLOBALS['stmts_below_minimum_amount'];
+    $reason .= "/n/n" . $ignoredstmts . " SELECTED STATEMENTS NOT PRINTED: ";
+    $reason .= "Statement amount value less than minimum value to print.";
+    fwrite($fhprint, $reason);
     fclose($fhprint);
     sleep(1);
 

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -234,13 +234,17 @@ $today = date("Y-m-d");
   // Print or download statements if requested.
   //
 if (($_POST['form_print'] || $_POST['form_download'] || $_POST['form_pdf'] || $_POST['form_portalnotify']) && $_POST['form_cb']) {
-    //some global variables to keep count of statements ignored in final print due to:
+    //some global variables to keep count of statements ignored
+    //and corresponding patient names, in final print due to:
     //1) having amount value less than minimum amount to print
     $GLOBALS['stmts_below_minimum_amount'] = 0;
+    $GLOBALS['pat_below_minimum_amount'] = array();
     //2) the patient is set to no statement
     $GLOBALS['stmts_set_no_patient'] = 0;
+    $GLOBALS['pat_set_no_stmt'] = array();
     //3) the insurance company does not allow statements
     $GLOBALS['stmts_not_allowed_insurance_company'] = 0;
+    $GLOBALS['pat_not_allowed_insurance_company'] = array();
 
     $fhprint = fopen($STMT_TEMP_FILE, 'w');
     $sqlBindArray = array();
@@ -415,8 +419,9 @@ if ($_POST['form_portalnotify']) {
 
     if (!empty($stmt)) ++$stmt_count;
     fwrite($fhprint, make_statement($stmt));
-    //logging the reason for not printing some statements
-    //as well as count of such statements
+
+    //logging the reason for not printing some statements, their count
+    //and corresponding patient names
     $countCase1 = (string)$GLOBALS['stmts_below_minimum_amount'];
     $countCase2 = (string)$GLOBALS['stmts_set_no_patient'];
     $countCase3 = (string)$GLOBALS['stmts_not_allowed_insurance_company'];
@@ -425,16 +430,28 @@ if ($_POST['form_portalnotify']) {
       //reason for case 1
       $reason .= $countCase1 . " SELECTED STATEMENTS NOT PRINTED: ";
       $reason .= "Statement amount value less than minimum amount value to print.";
+      $reason .= "\n  PATIENT NAMES: ";
+      foreach ($GLOBALS['pat_below_minimum_amount'] as $pat_name) {
+        $reason .= "{$pat_name}  ";
+      }
     }
     if ($countCase2 != 0) {
       //reason for case 2
       $reason .= "\n\n" . $countCase2 . " SELECTED STATEMENTS NOT PRINTED: ";
       $reason .= "The patient is set to no statement";
+      $reason .= "\n  PATIENT NAMES: ";
+      foreach ($GLOBALS['pat_set_no_stmt'] as $pat_name) {
+        $reason .= "{$pat_name}  ";
+      }
     }
     if ($countCase3 != 0) {
       //reason for case 3
       $reason .= "\n\n" . $countCase3 . " SELECTED STATEMENTS NOT PRINTED: ";
       $reason .= "The insurance company does not allow statements";
+      $reason .= "\n  PATIENT NAMES: ";
+      foreach ($GLOBALS['pat_not_allowed_insurance_company'] as $pat_name) {
+        $reason .= "{$pat_name}  ";
+      }
     }
     fwrite($fhprint, $reason);
     fclose($fhprint);

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -234,9 +234,14 @@ $today = date("Y-m-d");
   // Print or download statements if requested.
   //
 if (($_POST['form_print'] || $_POST['form_download'] || $_POST['form_pdf'] || $_POST['form_portalnotify']) && $_POST['form_cb']) {
-    //global variable to keep count of statements ignored
-    //ignored statements have amount value less than minimum amount to print
+    //some global variables to keep count of statements ignored in final print due to:
+    //1) having amount value less than minimum amount to print
     $GLOBALS['stmts_below_minimum_amount'] = 0;
+    //2) the patient is set to no statement
+    $GLOBALS['stmts_set_no_patient'] = 0;
+    //3) the insurance company does not allow statements
+    $GLOBALS['stmts_not_allowed_insurance_company'] = 0;
+
     $fhprint = fopen($STMT_TEMP_FILE, 'w');
     $sqlBindArray = array();
     $where = "";
@@ -411,9 +416,19 @@ if ($_POST['form_portalnotify']) {
     if (!empty($stmt)) ++$stmt_count;
     fwrite($fhprint, make_statement($stmt));
     //logging the reason for not printing some statements
-    $ignoredstmts = (string)$GLOBALS['stmts_below_minimum_amount'];
-    $reason .= "/n/n" . $ignoredstmts . " SELECTED STATEMENTS NOT PRINTED: ";
-    $reason .= "Statement amount value less than minimum value to print.";
+    //as well as count of such statements
+    $countCase1 = (string)$GLOBALS['stmts_below_minimum_amount'];
+    $countCase2 = (string)$GLOBALS['stmts_set_no_patient'];
+    $countCase3 = (string)$GLOBALS['stmts_not_allowed_insurance_company'];
+    //reason for case 1
+    $reason = "/n/n" . $countCase1 . " SELECTED STATEMENTS NOT PRINTED: ";
+    $reason .= "Statement amount value less than minimum amount value to print.";
+    //reason for case 2
+    $reason .= "/n/n" . $countCase2 . " SELECTED STATEMENTS NOT PRINTED: ";
+    $reason .= "The patient is set to no statement";
+    //reason for case 3
+    $reason .= "/n/n" . $countCase3 . " SELECTED STATEMENTS NOT PRINTED: ";
+    $reason .= "The insurance company does not allow statements";
     fwrite($fhprint, $reason);
     fclose($fhprint);
     sleep(1);

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -106,13 +106,22 @@ function create_HTML_statement($stmt) {
 
   #minimum_amount_due_to _print
   if ($stmt['amount'] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) {
-    //increment whenever statement is ignored due to if condition
+    //increment whenever amount value of statement is less than minimum amount value and
+    //to keep count of such ignored statements in final print
     $GLOBALS['stmts_below_minimum_amount']++;
     return "";
   }
 
-  if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) return "";
+  if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) {
+    //increment whenever the patient is set to no statement and
+    //to keep count of such ignored statements in final print
+    $GLOBALS['stmts_set_no_patient']++;
+    return "";
+  }
   if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
+   //increment whenever the insurance company does not allow statements and
+   //to keep count of such ignored statements in final print
+   $GLOBALS['stmts_not_allowed_insurance_company']++;
    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) return "";
@@ -472,13 +481,22 @@ function create_statement($stmt) {
 
  #minimum_amount_to _print
  if ($stmt[amount] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) {
-    //increment whenever statement is ignored due to if condition
+    //increment whenever amount value of statement is less than minimum amount value and
+    //to keep count of such ignored statements in final print
     $GLOBALS['stmts_below_minimum_amount']++;
     return "";
   }
 
- if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) return "";
+ if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) {
+    //increment whenever the patient is set to no statement and
+    //to keep count of such ignored statements in final print
+    $GLOBALS['stmts_set_no_patient']++;
+    return "";
+  };
  if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
+   //increment whenever the insurance company does not allow statements and
+   //to keep count of such ignored statements in final print
+   $GLOBALS['stmts_not_allowed_insurance_company']++;
    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) return "";

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -105,7 +105,12 @@ function create_HTML_statement($stmt) {
   if (! $stmt['pid']) return ""; // get out if no data
 
   #minimum_amount_due_to _print
-  if ($stmt['amount'] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) return "";
+  if ($stmt['amount'] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) {
+    //increment whenever statement is ignored due to if condition
+    $GLOBALS['stmts_below_minimum_amount']++;
+    return "";
+  }
+
   if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) return "";
   if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
@@ -172,7 +177,7 @@ function create_HTML_statement($stmt) {
   $label_addressee = xl('ADDRESSEE');
   $label_remitto = xl('REMIT TO');
   $label_chartnum = xl('Chart Number');
-  if ($GLOBALS['show_insurance_name_on_custom_statement']) { 
+  if ($GLOBALS['show_insurance_name_on_custom_statement']) {
    if (strlen($stmt['insconum2']) !=0){
       $label_insinfo = xl('Insurance Companies '). $stmt['insconum1'] . ', '. $stmt['insconum2'];
    }
@@ -466,7 +471,12 @@ function create_statement($stmt) {
  if (! $stmt['pid']) return ""; // get out if no data
 
  #minimum_amount_to _print
- if ($stmt[amount] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) return "";
+ if ($stmt[amount] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) {
+    //increment whenever statement is ignored due to if condition
+    $GLOBALS['stmts_below_minimum_amount']++;
+    return "";
+  }
+
  if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) return "";
  if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
@@ -545,7 +555,7 @@ if ($GLOBALS['use_dunning_message']) {
  $label_addressee = xl('ADDRESSEE');
  $label_remitto = xl('REMIT TO');
  $label_chartnum = xl('Chart Number');
- if ($GLOBALS['show_insurance_name_on_custom_statement']) { 
+ if ($GLOBALS['show_insurance_name_on_custom_statement']) {
    if (strlen($stmt['insconum2']) !=0){
       $label_insinfo = xl('Insurance Companies '). $stmt['insconum1'] . ', '. $stmt['insconum2'];
    }
@@ -555,8 +565,8 @@ if ($GLOBALS['use_dunning_message']) {
    }
  }else{
  $label_insinfo = xl('Insurance information on file');
- }    
- 
+ }
+
  $label_totaldue = xl('Total amount due');
  $label_payby = xl('If paying by');
  $label_cards = xl('VISA/MC/AMEX/Dis');
@@ -821,7 +831,7 @@ function osp_create_HTML_statement($stmt) {
   $label_addressee = xl('ADDRESSEE');
   $label_remitto = xl('REMIT TO');
   $label_chartnum = xl('Chart Number');
- if ($GLOBALS['show_insurance_name_on_custom_statement']) { 
+ if ($GLOBALS['show_insurance_name_on_custom_statement']) {
    if (strlen($stmt['insconum2']) !=0){
       $label_insinfo = xl('Insurance Companies '). $stmt['insconum1'] . ', '. $stmt['insconum2'];
    }
@@ -830,7 +840,7 @@ function osp_create_HTML_statement($stmt) {
      $label_insinfo = xl('Insurance Company '). $stmt['insconum1'] ;
    }
  }else{
-    $label_insinfo = xl('Insurance information on file');  
+    $label_insinfo = xl('Insurance information on file');
  }
   $label_totaldue = xl('Total amount due');
   $label_payby = xl('If paying by');

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -127,15 +127,31 @@ function create_HTML_statement($stmt) {
     return "";
   }
   if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
-   //increment whenever the insurance company does not allow statements,
-   //to keep count of such ignored statements in final print
-   $GLOBALS['stmts_not_allowed_insurance_company']++;
-   //also add corresponding patient name
-   array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
-   if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
-   if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) return "";
-   if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) return "";
-   if ($GLOBALS['insurance_statement_exclude'] ==3) return "";
+    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) {
+      //increment whenever the insurance company does not allow statements,
+      //to keep count of such ignored statements in final print
+      $GLOBALS['stmts_not_allowed_insurance_company']++;
+      //also add corresponding patient name
+      array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
+      return "";
+    }
+    if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) {
+      //increment whenever the insurance company does not allow statements,
+      //to keep count of such ignored statements in final print
+      $GLOBALS['stmts_not_allowed_insurance_company']++;
+      //also add corresponding patient name
+      array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
+      return "";
+    }
+    if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) {
+      //increment whenever the insurance company does not allow statements,
+      //to keep count of such ignored statements in final print
+      $GLOBALS['stmts_not_allowed_insurance_company']++;
+      //also add corresponding patient name
+      array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
+      return "";
+    }
+    if ($GLOBALS['insurance_statement_exclude'] ==3) return "";
   }
 
   // Don't print if decreased
@@ -508,15 +524,31 @@ function create_statement($stmt) {
     return "";
   };
  if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
-   //increment whenever the insurance company does not allow statements,
-   //to keep count of such ignored statements in final print
-   $GLOBALS['stmts_not_allowed_insurance_company']++;
-   //also add corresponding patient name
-   array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
-   if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
-   if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) return "";
-   if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) return "";
-   if ($GLOBALS['insurance_statement_exclude'] ==3) return "";
+    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) {
+      //increment whenever the insurance company does not allow statements,
+      //to keep count of such ignored statements in final print
+      $GLOBALS['stmts_not_allowed_insurance_company']++;
+      //also add corresponding patient name
+      array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
+      return "";
+    }
+    if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) {
+      //increment whenever the insurance company does not allow statements,
+      //to keep count of such ignored statements in final print
+      $GLOBALS['stmts_not_allowed_insurance_company']++;
+      //also add corresponding patient name
+      array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
+      return "";
+    }
+    if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) {
+      //increment whenever the insurance company does not allow statements,
+      //to keep count of such ignored statements in final print
+      $GLOBALS['stmts_not_allowed_insurance_company']++;
+      //also add corresponding patient name
+      array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
+      return "";
+    }
+    if ($GLOBALS['insurance_statement_exclude'] ==3) return "";
   }
 
  // Don't print if decreased

--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -39,6 +39,10 @@ $STMT_PRINT_CMD = $GLOBALS['print_command'];
  *      Further customize 2. manually in functions report_2() and create_HTML_statement(), below.
  *
  */
+
+//for getPatientName function
+require_once("../../library/patient.inc");
+
 function make_statement($stmt) {
   if ($GLOBALS['statement_appearance'] == "1") {
     if(is_auth_portal($stmt['pid']) && $_POST['form_portalnotify'])
@@ -106,22 +110,28 @@ function create_HTML_statement($stmt) {
 
   #minimum_amount_due_to _print
   if ($stmt['amount'] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) {
-    //increment whenever amount value of statement is less than minimum amount value and
+    //increment whenever amount value of statement is less than minimum amount value,
     //to keep count of such ignored statements in final print
     $GLOBALS['stmts_below_minimum_amount']++;
+    //also add corresponding patient name
+    array_push($GLOBALS['pat_below_minimum_amount'], getPatientName($stmt['pid']));
     return "";
   }
 
   if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) {
-    //increment whenever the patient is set to no statement and
+    //increment whenever the patient is set to no statement,
     //to keep count of such ignored statements in final print
     $GLOBALS['stmts_set_no_patient']++;
+    //also add corresponding patient name
+    array_push($GLOBALS['pat_set_no_stmt'], getPatientName($stmt['pid']));
     return "";
   }
   if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
-   //increment whenever the insurance company does not allow statements and
+   //increment whenever the insurance company does not allow statements,
    //to keep count of such ignored statements in final print
    $GLOBALS['stmts_not_allowed_insurance_company']++;
+   //also add corresponding patient name
+   array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) return "";
@@ -481,22 +491,28 @@ function create_statement($stmt) {
 
  #minimum_amount_to _print
  if ($stmt[amount] <= ($GLOBALS['minimum_amount_to_print']) && $GLOBALS['use_statement_print_exclusion']) {
-    //increment whenever amount value of statement is less than minimum amount value and
+    //increment whenever amount value of statement is less than minimum amount value,
     //to keep count of such ignored statements in final print
     $GLOBALS['stmts_below_minimum_amount']++;
+    //also add corresponding patient name
+    array_push($GLOBALS['pat_below_minimum_amount'], getPatientName($stmt['pid']));
     return "";
   }
 
  if ($stmt['statement_print'] == "NO" && $GLOBALS['use_statement_print_exclusion']) {
-    //increment whenever the patient is set to no statement and
+    //increment whenever the patient is set to no statement,
     //to keep count of such ignored statements in final print
     $GLOBALS['stmts_set_no_patient']++;
+    //also add corresponding patient name
+    array_push($GLOBALS['pat_set_no_stmt'], getPatientName($stmt['pid']));
     return "";
   };
  if ($GLOBALS['use_statement_print_exclusion'] && $GLOBALS['insurance_statement_exclude'] !=4 ){
-   //increment whenever the insurance company does not allow statements and
+   //increment whenever the insurance company does not allow statements,
    //to keep count of such ignored statements in final print
    $GLOBALS['stmts_not_allowed_insurance_company']++;
+   //also add corresponding patient name
+   array_push($GLOBALS['pat_not_allowed_insurance_company'], getPatientName($stmt['pid']));
    if ($GLOBALS['insurance_statement_exclude'] ==0 && $stmt['insurance_no_statement_print_pri']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==1 && $stmt['insurance_no_statement_print_sec']) return "";
    if ($GLOBALS['insurance_statement_exclude'] ==2 && $stmt['insurance_no_statement_print_tri']) return "";


### PR DESCRIPTION
Fixes #858 

Added a GLOBAL variable `$GLOBALS['stmts_below_minimum_amount']` to keep count of ignored statements having amount value less than `$GLOBALS['minimum_amount_to_print']`. This reason along with number of ignored statements are logged to user at end of `$STMT_TEMP_FILE` after all the `make_statement` calls are done.

One way to see the changes _locally_ would be as follows:
1) Clone my repo via `git clone https://github.com/apooravc/LibreEHR.git`
2) After cloning, only the master branch would be available locally. Enter `git checkout -b log-reasons origin/log-reasons` or `git branch log-reasons origin/log-reasons` to get the branch _log-reasons_ locally.
3) The changes could then be seen on Fees/Posting page.

@teryhill Please have a look.