### PR TITLE
Fix for #242: Notify when globals saved

### DIFF
--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -1,5 +1,5 @@
 <?php
-/** 
+/**
  * Edit Globals
  *
  * This program allows the editing of the system Globals
@@ -10,7 +10,7 @@
  * LICENSE: This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 3
- * of the License, or (at your option) any later version. 
+ * of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
@@ -43,7 +43,7 @@ if ($_GET['mode'] != "user") {
 }
 
 function checkCreateCDB(){
-  $globalsres = sqlStatement("SELECT gl_name, gl_index, gl_value FROM globals WHERE gl_name IN 
+  $globalsres = sqlStatement("SELECT gl_name, gl_index, gl_value FROM globals WHERE gl_name IN
   ('couchdb_host','couchdb_user','couchdb_pass','couchdb_port','couchdb_dbase','document_storage_method')");
     $options = array();
     while($globalsrow = sqlFetchArray($globalsres)){
@@ -53,7 +53,7 @@ function checkCreateCDB(){
   if($GLOBALS['document_storage_method'] != 0){
     // /documents/temp/ folder is required for CouchDB
     if(!is_dir($GLOBALS['OE_SITE_DIR'] . '/documents/temp/')){
-      $directory_created = mkdir($GLOBALS['OE_SITE_DIR'] . '/documents/temp/',0777,true);      
+      $directory_created = mkdir($GLOBALS['OE_SITE_DIR'] . '/documents/temp/',0777,true);
       if(!$directory_created){
     echo htmlspecialchars( xl("Failed to create temporary folder. CouchDB will not work."),ENT_NOQUOTES);
       }
@@ -153,7 +153,7 @@ if ($_POST['form_save'] && $_GET['mode'] == "user") {
               $boolean = "false";
             }
           }
-          if ($boolean) { 
+          if ($boolean) {
           $label = "global:".$fldid;
           $fldvalue = trim(strip_escape_custom($_POST["form_$i"]));
           setUserSetting($label,$fldvalue,$_SESSION['authId'],FALSE);
@@ -197,7 +197,7 @@ if ($_POST['form_save'] && $_GET['mode'] != "user") {
    * Compare form values with old database values.
    * Only save if values differ. Improves speed.
    */
-  
+
   // Get all the globals from DB
   $old_globals = sqlGetAssoc( 'SELECT gl_name, gl_index, gl_value FROM `globals` ORDER BY gl_name, gl_index',false,true );
 
@@ -214,9 +214,9 @@ if ($_POST['form_save'] && $_GET['mode'] != "user") {
       if (!is_array($fldtype) && substr($fldtype, 0, 2) == 'm_') {
         if (isset($_POST["form_$i"])) {
           $fldindex = 0;
-          
+
           sqlStatement("DELETE FROM globals WHERE gl_name = ?", array( $fldid ) );
-          
+
           foreach ($_POST["form_$i"] as $fldvalue) {
             $fldvalue = trim($fldvalue);
             sqlStatement('INSERT INTO `globals` ( gl_name, gl_index, gl_value ) VALUES ( ?,?,?)', array( $fldid, $fldindex, $fldvalue )  );
@@ -235,10 +235,10 @@ if ($_POST['form_save'] && $_GET['mode'] != "user") {
         if($fldtype=='pwd') $fldvalue = $fldvalue ? SHA1($fldvalue) : $fldvalueold;
 
         // We rely on the fact that set of keys in globals.inc === set of keys in `globals`  table!
-        
-        if( 
+
+        if(
              !isset( $old_globals[$fldid]) // if the key not found in database - update database
-              ||              
+              ||
              ( isset($old_globals[$fldid]) && $old_globals[ $fldid ]['gl_value'] !== $fldvalue ) // if the value in database is different
         ) {
             // Need to force enable_auditlog_encryption off if the php mcrypt module
@@ -374,6 +374,16 @@ input     { font-size:10pt; }
 
 <body class="body_top">
 
+<!--Settings Saved Notification for Globals-->
+<div id="set_alert" style="width: 130px; background-color: #2ECC40; color: #fff; font-weight: bold; font-size: 17px; text-align: center; margin-bottom: 5px; display: none;">Settings Saved</div>
+<?php if ($_GET['unique'] == "yes") { ?>
+<script type="text/javascript">
+  $(document).ready(function() {
+    $("div#set_alert").css("display", "block").fadeOut(3000);
+  });
+</script>
+<?php } ?>
+
 <?php if ($_GET['mode'] == "user") { ?>
   <form method='post' name='theform' id='theform' action='edit_globals.php?mode=user' onsubmit='return top.restoreSession()'>
 <?php } else { ?>
@@ -407,7 +417,7 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
   }
 }
 ?>
-</ul> 
+</ul>
 
 <div class="tabContainer well" style="height: 75%; overflow: auto;">
 <?php
@@ -555,7 +565,7 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
       }else{
         $top_choice = $flddef;
       }
-      echo "    <option value=''>" . text($top_choice) . "\n";      
+      echo "    <option value=''>" . text($top_choice) . "\n";
       while ($row = sqlFetchArray($res)) {
         $title = $row['title'];
         echo "   <option value='" . attr($title) . "'";
@@ -764,8 +774,8 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
     }
     ++$i;
    }
-  }  
-  echo " </table>\n";  
+  }
+  echo " </table>\n";
   echo " </div>\n";
  }
 }


### PR DESCRIPTION
Fixes #242 
When the user clicks on save, and the edit_globals iframe is refreshed, there is no notification given to users. This PR adds a notification shown below which fades out after `3 seconds`:
![image1](https://user-images.githubusercontent.com/25399108/37891531-4049010e-30f2-11e8-9e8d-d38a0fae7d43.JPG)

Works on the value of `$_GET['unique']` which is `null` on first opening edit_globals or refreshing it by clicking on refresh icon. It becomes equal to `yes` after clicking on save button.

@aethelwulffe @teryhill Please have a look.